### PR TITLE
New box CSS

### DIFF
--- a/src/components/Breadcrumbs.module.css
+++ b/src/components/Breadcrumbs.module.css
@@ -5,7 +5,7 @@
   font-family: var(--maru-mono);
   color: var(--red);
   font-size: var(--font-medium);
-  line-height: var(--baseline);
+  line-height: var(--baseline-box);
 }
 
 .arrow {

--- a/src/components/Filter.module.css
+++ b/src/components/Filter.module.css
@@ -5,10 +5,7 @@
 }
 
 .left {
-  flex: 0 0 var(--baseline);
-  /* display: flex;
-  align-items: center;
-  justify-content: center; */
+  flex: 0 0 var(--baseline-box);
 }
 
 .right {
@@ -16,12 +13,12 @@
 }
 
 .icon {
-  line-height: var(--baseline);
+  line-height: var(--baseline-box);
   text-align: center;
 }
 
 .title {
-  line-height: var(--baseline);
+  line-height: var(--baseline-box);
   padding-left: var(--box-padding);
 
   & h3 {
@@ -42,7 +39,7 @@
     width: 100%;
     cursor: pointer;
     padding: 0 var(--spacing-xsmall);
-    line-height: var(--baseline);
+    line-height: var(--baseline-box);
     font-family: var(--maru-mono);
     font-size: var(--medium);
     color: var(--gray-mid);

--- a/src/components/Heading.module.css
+++ b/src/components/Heading.module.css
@@ -3,7 +3,7 @@
 
   & h1 {
     color: var(--red);
-    line-height: calc(var(--baseline) * 3);
+    line-height: var(--baseline-box-3x);
     margin: 0;
     font-size: 140px;
   }

--- a/src/styles/box.module.css
+++ b/src/styles/box.module.css
@@ -1,14 +1,12 @@
 /*
   These classes help streamline the creation of layout boxes across the site.
   Boxes can be next to each other and nested under each other, and they will
-  still only show a single, collapsed border to each other. The only rule is
-  that is you nest boxes, there cannot be a child that doesn't have the .box
-  class. It must be boxes all the way down.
+  still only show a single, collapsed border to each other.
 */
+
 .box {
   border: var(--border);
   border-top: none;
-  margin-bottom: -1px;
   margin-right: -1px;
 }
 

--- a/src/styles/pages/components.module.css
+++ b/src/styles/pages/components.module.css
@@ -1,3 +1,3 @@
 .box {
-  line-height: var(--baseline);
+  line-height: var(--baseline-box);
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -4,6 +4,17 @@
 @custom-media --xlarge (max-width: 1440px);
 
 :root {
+  /* This is the real baseline from top to bottom */
+  --baseline: 50px;
+
+  /*
+    This is the baseline that content inside boxes should rely on.
+    We chose to do this instead of a negative margin on .box because
+    boxes would overlap and therefore cover the top line with background color, etc.
+  */
+  --baseline-box: calc(var(--baseline) - 1px);
+  --baseline-box-3x: calc(var(--baseline) * 2 + var(--baseline));
+
   --maru: "GT Maru", sans-serif;
   --maru-mega: "GT Maru Mega", sans-serif;
   --maru-mono: "GT Maru Mono", monospace;
@@ -28,8 +39,6 @@
   --red-light: #fffcfc;
 
   --border: 1px solid var(--gray-mid);
-
-  --baseline: 50px;
   --box-padding: 25px;
 
   --container-max-width: 1600px;


### PR DESCRIPTION
This small PR changes the box to no longer have a negative margin top, because it made boxes overlap and made it impossible to do hovers on background, etc. Instead, we now operate with two CSS variables:

- `var(--baseline)` is the real baseline
- `var(--baseline-box)` is the baseline minus the height of the bottom border

I think it's a pretty simple and nice change that makes it easier to code things. 

CC @Anadroid This doesn't fix the right/left problems with the boxes, which I'm looking at next.