### PR TITLE
More box tweaks

### DIFF
--- a/src/components/Filter.js
+++ b/src/components/Filter.js
@@ -27,8 +27,9 @@ const Filter = ({
 
   return (
     <div className={cn(css.root, className)}>
-      <div className={cn(box, css.left)}>
+      <div className={css.left}>
         <div className={cn(box, css.icon)}>Ⴤ</div>
+        <div className={cn(box, css.spacer)} />
       </div>
       <div className={css.right}>
         <div className={cn(box, css.title)}>

--- a/src/components/Filter.module.css
+++ b/src/components/Filter.module.css
@@ -6,6 +6,8 @@
 
 .left {
   flex: 0 0 var(--baseline-box);
+  display: flex;
+  flex-direction: column;
 }
 
 .right {
@@ -15,6 +17,10 @@
 .icon {
   line-height: var(--baseline-box);
   text-align: center;
+}
+
+.spacer {
+  flex: 1;
 }
 
 .title {

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -1,49 +1,50 @@
-import React, { useState } from "react";
-import { Link } from "gatsby";
-import cn from "classnames";
+import React, { useState } from 'react';
+import { Link } from 'gatsby';
+import cn from 'classnames';
 
-import * as css from "./Menu.module.css";
-import { box } from "../styles/box.module.css";
+import * as css from './Menu.module.css';
+import { box } from '../styles/box.module.css';
 
-import { AiOutlineMenu, AiOutlineClose } from "react-icons/ai";
+import { AiOutlineMenu, AiOutlineClose } from 'react-icons/ai';
 
 const items = [
   {
-    name: "Get Started",
-    href: "/",
+    name: 'Get Started',
+    href: '/'
   },
   {
-    name: "Videos",
+    name: 'Videos',
     children: [
-      { name: "Videos1", href: "" },
-      { name: "Videos2", href: "" },
-      { name: "Videos3", href: "" },
-    ],
+      { name: 'Videos1', href: '' },
+      { name: 'Videos2', href: '' },
+      { name: 'Videos3', href: '' }
+    ]
   },
   {
-    name: "Community",
-    href: "/",
+    name: 'Community',
+    href: '/'
   },
   {
-    name: "About",
-    href: "/",
-  },
+    name: 'About',
+    href: '/'
+  }
 ];
 
 const Menu = () => {
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className={cn(box, css.root)}>
-      <button className={css.menuToggle} onClick={() => setExpanded(!expanded)}>
+    <div className={css.root}>
+      <button
+        className={cn(box, css.menuToggle)}
+        onClick={() => setExpanded(!expanded)}>
         {expanded ? <AiOutlineClose size={24} /> : <AiOutlineMenu size={24} />}
       </button>
       <ul className={cn(css.menu, { [css.expanded]: expanded })}>
         {items.map((item, i) => (
           <li
             key={i}
-            className={cn(box, css.item, { [css.hasSubmenu]: item.children })}
-          >
+            className={cn(box, css.item, { [css.hasSubmenu]: item.children })}>
             {item.href ? (
               <Link to={item.href}>{item.name}</Link>
             ) : (
@@ -51,7 +52,7 @@ const Menu = () => {
                 <button>{item.name}</button>
                 <ul className={css.submenu}>
                   {item.children.map((subitem, j) => (
-                    <li className={css.subitem} key={j}>
+                    <li className={cn(box, css.subitem)} key={j}>
                       <Link to={subitem.href}>{subitem.name}</Link>
                     </li>
                   ))}

--- a/src/components/Menu.module.css
+++ b/src/components/Menu.module.css
@@ -13,7 +13,7 @@
   display: none;
   padding: 0 var(--box-padding);
   cursor: pointer;
-  line-height: var(--baseline);
+  line-height: var(--baseline-box);
 }
 
 .menu {
@@ -27,46 +27,45 @@
 
   & button {
     padding: 0;
-    line-height: var(--baseline);
+    line-height: var(--baseline-box);
     color: var(--gray-dark);
   }
 }
 
-button {
+.root button {
   text-transform: uppercase;
+}
+
+.item {
+  position: relative;
 }
 
 .item,
 .subitem {
+  white-space: nowrap;
   padding: 0 var(--box-padding);
   background-color: var(--gray-light);
   & a {
     text-decoration: none;
     color: var(--gray-dark);
-    line-height: var(--baseline);
+    line-height: var(--baseline-box);
   }
 }
 
-.subitem {
-  border: var(--border);
-  border-top: none;
+.submenu {
+  position: absolute;
+  z-index: 1;
+  left: -1px;
+  top: var(--baseline);
+  list-style: none;
+  display: none;
+  padding: 0;
 }
 
 .item.hasSubmenu:hover {
   & .submenu {
     display: block;
-    padding: 0;
-    position: absolute;
-    z-index: 1;
   }
-}
-
-.submenu {
-  list-style: none;
-  display: none;
-  padding: 0;
-  margin-top: 1px;
-  margin-left: -26px;
 }
 
 @media (--large) {
@@ -86,8 +85,8 @@ button {
     height: auto;
     flex-wrap: nowrap;
     position: absolute;
-    right: 50px;
-    top: 50px;
+    right: var(--baseline);
+    top: var(--baseline);
 
     background-color: var(--gray-light);
 

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -1,16 +1,16 @@
-import React from "react";
-import cn from "classnames";
-import Menu from "./Menu";
+import React from 'react';
+import cn from 'classnames';
+import Menu from './Menu';
 
-import * as css from "./TopBar.module.css";
-import { box } from "../styles/box.module.css";
+import * as css from './TopBar.module.css';
+import { box } from '../styles/box.module.css';
 
-import Logo from "../images/logo.svg";
-import Clock from "../images/clock.svg";
+import Logo from '../images/logo.svg';
+import Clock from '../images/clock.svg';
 
 const TopBar = () => {
   return (
-    <div className={cn(box, css.root)}>
+    <div className={css.root}>
       <div className={cn(box, css.logo)}>
         <Logo width={250} />
       </div>

--- a/src/components/TopBar.module.css
+++ b/src/components/TopBar.module.css
@@ -6,17 +6,17 @@
 }
 
 .logo {
-  line-height: var(--baseline);
+  line-height: var(--baseline-box);
   padding: 0 var(--box-padding);
 }
 
 .clock {
-  line-height: var(--baseline);
+  line-height: var(--baseline-box);
   padding: 0 var(--box-padding);
 }
 
 .date {
-  line-height: var(--baseline);
+  line-height: var(--baseline-box);
   flex: 1;
   text-align: center;
   text-transform: uppercase;

--- a/src/pages/components.js
+++ b/src/pages/components.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Layout from '../components/Layout';
 import Heading from '../components/Heading';
-import Breadcrumb from '../components/Breadcrumbs';
+import Breadcrumbs from '../components/Breadcrumbs';
 import TopBar from '../components/TopBar';
 import Filter from '../components/Filter';
 import cn from 'classnames';
@@ -17,7 +17,7 @@ const ComponentsPage = () => {
     <Layout>
       <TopBar />
       <Heading>This is a heading</Heading>
-      <Breadcrumb
+      <Breadcrumbs
         breadcrumbs={[
           { name: 'Videos Overview', link: '' },
           { name: 'Tracks', link: '' },
@@ -68,16 +68,14 @@ const ComponentsPage = () => {
         <div className={cn(box, col, css.box)}>Box 6</div>
         <div className={cn(box, col, css.box)}>Box 7</div>
       </div>
-      <div className={cn(box, css.box)}>
-        <div className={cols}>
-          <div className={cn(box, col, css.box)}>Nested 1</div>
-          <div className={cn(box, col, css.box)}>Nested 2</div>
-        </div>
-        <div className={cols}>
-          <div className={cn(box, col, css.box)}>Nested 4</div>
-          <div className={cn(box, col, css.box)}>Nested 5</div>
-          <div className={cn(box, col, css.box)}>Nested 6</div>
-        </div>
+      <div className={cols}>
+        <div className={cn(box, col, css.box)}>Nested 1</div>
+        <div className={cn(box, col, css.box)}>Nested 2</div>
+      </div>
+      <div className={cols}>
+        <div className={cn(box, col, css.box)}>Nested 4</div>
+        <div className={cn(box, col, css.box)}>Nested 5</div>
+        <div className={cn(box, col, css.box)}>Nested 6</div>
       </div>
       <div className={cn(box, css.box)}>Box 8</div>
     </Layout>

--- a/src/styles/box.module.css
+++ b/src/styles/box.module.css
@@ -2,20 +2,13 @@
   These classes help streamline the creation of layout boxes across the site.
   Boxes can be next to each other and nested under each other, and they will
   still only show a single, collapsed border to each other.
+  .box cannot be nested under .box
 */
 
 .box {
   border: var(--border);
   border-top: none;
   margin-right: -1px;
-}
-
-.box .box {
-  margin-left: -1px;
-}
-
-.box .box + .box {
-  margin-left: 0;
 }
 
 /* A few classes to help split the container */

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -13,7 +13,7 @@
     boxes would overlap and therefore cover the top line with background color, etc.
   */
   --baseline-box: calc(var(--baseline) - 1px);
-  --baseline-box-3x: calc(var(--baseline) * 2 + var(--baseline));
+  --baseline-box-3x: calc(var(--baseline) * 2 + var(--baseline-box));
 
   --maru: "GT Maru", sans-serif;
   --maru-mega: "GT Maru Mega", sans-serif;


### PR DESCRIPTION
Hi @Anadroid 

I spent some time this evening looking at the `.box` class (per my earlier PR), and I realized that the far easiest is to make a `.box` class that doesn't allow nesting. So, I rewrote the menu component with these changes in mind, and you'll see that it works much better now. I also changed the menu to use the new `var(--baseline-box)` CSS variable.

I did not touch the mobile version, since we will talk about that tomorrow. Feel free to merge this when you have seen and understood the changes. There are some extra `Filter` tweaks in here too :) 