### PR TITLE
Contribution Panel URL refactor

### DIFF
--- a/src/components/ContributionsPanel.js
+++ b/src/components/ContributionsPanel.js
@@ -8,74 +8,80 @@ import * as css from './ContributionsPanel.module.css';
 import PlayButton from '../images/playbutton.svg';
 
 const ContributionsPanel = ({ contributions, placeholderImage }) => {
+  const description =
+    contributions.length > 0
+      ? 'What our community has done based on this video'
+      : 'No contributions done yet!';
   return (
     <div className={css.root}>
       <div className={css.titleBox}>
         <h4>Community contributions</h4>
-        <p>
-          {contributions.length > 0
-            ? 'What our community has done based on this video'
-            : 'No contributions done yet!'}
-        </p>
+        <p>{description}</p>
       </div>
       <div className={css.contributions}>
         {contributions.map((contrib, key) => (
           <Fragment key={key}>
-            <div className={css.contrib}>
-              <span className={css.title}>{contrib.title}</span>
-              {contrib.cover ? (
-                <Image
-                  image={contrib.cover.file.childImageSharp.gatsbyImageData}
-                  pictureClassName={css.picture}
-                  imgClassName={css.image}
-                />
-              ) : placeholderImage ? (
-                <Image
-                  image={placeholderImage}
-                  pictureClassName={css.picture}
-                  imgClassName={css.image}
-                />
-              ) : (
-                <div className={css.imagePlaceholder}></div>
-              )}
-              <p className={css.author}>
-                {contrib.author.url ? (
-                  <a
-                    href={contrib.author.url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className={css.authorName}>
-                    {contrib.author.name}
-                  </a>
-                ) : (
-                  <span className={css.authorName}>{contrib.author.name}</span>
-                )}
-                <a
-                  href={
-                    contrib.url ??
-                    (contrib.videoId
-                      ? `https://youtu.be/${contrib.videoId}`
-                      : contrib.source)
-                  }
-                  target="_blank"
-                  rel="noreferrer"
-                  className={css.playButton}>
-                  <PlayButton width={30} />
-                </a>
-              </p>
-            </div>
+            <Contribution
+              contribution={contrib}
+              placeholderImage={placeholderImage}
+            />
             <div className={css.spacer}></div>
           </Fragment>
         ))}
       </div>
       <ButtonPanel
-        text={'Have you completed a project? Share your work!'}
-        buttonText={'Submit a contribution'}
-        buttonLink={''}
-        variant={'purple'}
+        text="Have you completed a project? Share your work!"
+        buttonText="Submit a contribution"
+        buttonLink=""
+        variant="purple"
         className={css.contribsPanel}
         smallWrap={true}
       />
+    </div>
+  );
+};
+
+const Contribution = ({ contribution, placeholderImage }) => {
+  const { title, cover, author } = contribution;
+  const image = cover
+    ? contribution.cover.file.childImageSharp.gatsbyImageData
+    : placeholderImage;
+  const url =
+    contribution.url ??
+    (contribution.videoId
+      ? `https://youtu.be/${contribution.videoId}`
+      : contribution.source);
+  return (
+    <div className={css.contrib}>
+      <a className={css.title} href={url} target="_blank" rel="noreferrer">
+        {title}
+      </a>
+      <a
+        className={css.pictureContainer}
+        href={url}
+        target="_blank"
+        rel="noreferrer">
+        {image ? (
+          <Image image={image} imgClassName={css.image} />
+        ) : (
+          <div className={css.noImage} />
+        )}
+        <PlayButton width={30} className={css.playButton} />
+      </a>
+      <p className={css.author}>
+        <span>by </span>
+        {author.url ? (
+          <a
+            href={author.url}
+            target="_blank"
+            rel="noreferrer"
+            className={css.authorName}>
+            {author.name}
+          </a>
+        ) : (
+          <span className={css.authorName}>{author.name}</span>
+        )}
+      </p>
     </div>
   );
 };

--- a/src/components/ContributionsPanel.module.css
+++ b/src/components/ContributionsPanel.module.css
@@ -74,6 +74,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+  text-decoration: underline;
 }
 
 .author {
@@ -81,10 +82,10 @@
   border-left: var(--border-purple);
   line-height: var(--baseline-box);
   display: flex;
-  justify-content: space-between;
   align-items: center;
   margin: 0;
   padding: 0 calc(var(--box-padding) / 2);
+  color: var(--gray-mid);
 }
 
 .authorName {
@@ -92,24 +93,15 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-}
-
-.playButton {
-  height: var(--baseline-box);
+  padding: 0 calc(var(--box-padding) / 2);
 }
 
 a.authorName {
   text-decoration: underline;
 }
 
-.imagePlaceholder {
-  height: var(--baseline-3x);
-  background-color: var(--gray-light);
-  border-bottom: var(--border-purple);
-  border-left: var(--border-purple);
-}
-
-.picture {
+.pictureContainer {
+  position: relative;
   height: var(--baseline-3x);
   border-bottom: var(--border-purple);
   border-left: var(--border-purple);
@@ -119,6 +111,16 @@ a.authorName {
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.noImage {
+  background-color: var(--gray-light);
+}
+
+.playButton {
+  position: absolute;
+  bottom: calc(var(--box-padding) / 4);
+  right: calc(var(--box-padding) / 4);
 }
 
 @media (--medium) {
@@ -136,7 +138,7 @@ a.authorName {
     width: 300px;
     flex: 0 0 300px;
   }
-  .imagePlaceholder {
+  .pictureContainer {
     height: var(--baseline-4x);
   }
 }


### PR DESCRIPTION
This PR refactors how the URLs are placed in the community contributions panel. It also tidies the code itself a bit. It takes ideas posted by @shiffman in #48 and also moves play button to a more natural place.

EDIT: I thought a preview would be generated, but I guess it doesn't unless the PR is to main.
To be clear, then changes made are:
- Sketch title and thumbnail be clickable and take you to the sketch.
- Added the word "by" to "by Author Name"
- Moved the Play icon button to the corner on top of the thumbnail itself, so it's more obvious it can be interacted or "played" with.

So it goes from this:
![](https://user-images.githubusercontent.com/191758/151248313-4b95150f-6ce6-4155-b013-6dafd2141604.png)

To this:
<img width="1343" alt="Screen Shot 2022-01-27 at 15 25 48" src="https://user-images.githubusercontent.com/13511560/151420766-3f323f78-172e-4006-be12-3c6dd0451ae8.png">

This PR also hopefullly resolves #48 
