### PR TITLE
🔧 Little front-end tweaks

### DIFF
--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -14,7 +14,7 @@ export const Tabs = ({ className, variant, labels, children, shareLink }) => {
   };
 
   useEffect(() => {
-    if (!isFirstRender.current) {
+    if (!isFirstRender.current && window.innerWidth < 600) {
       const tab = document.getElementById(`#component-tab-${active}`);
       tab.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }

--- a/src/components/Tags.js
+++ b/src/components/Tags.js
@@ -4,12 +4,12 @@ import cn from 'classnames';
 import * as css from './Tags.module.css';
 
 const Tags = memo(({ className, heading, items, singleLine = true }) => {
-  const visibleItems = items.slice(0, 2);
+  // const visibleItems = items.slice(0, 2);
   // const hiddenItems = items.slice(2);
   return (
     <div className={cn(css.root, className, { [css.singleLine]: singleLine })}>
       <h4 className={css.tagHeading}>{heading}</h4>
-      {visibleItems.map((tag) => (
+      {items.map((tag) => (
         <span className={css.tag} key={tag}>
           {tag}
         </span>


### PR DESCRIPTION
This tweaks some front-end issues:
- For #61: Extends `Tags` component to show any number of items, not only two.
- For #62:  Disabled scrolling in `Tabs` components for large screen sizes.