### PR TITLE
Visual tweaks and fixes

### DIFF
--- a/src/components/Button.module.css
+++ b/src/components/Button.module.css
@@ -70,7 +70,7 @@ button.rainbow.red {
   );
   background-size: 20000% 100%;
   background-position: right bottom;
-  transition: all 1s ease-out;
+  transition: background-position 1s ease-out;
 }
 
 a.rainbow.orange,
@@ -86,7 +86,7 @@ button.rainbow.orange {
   );
   background-size: 20000% 100%;
   background-position: right bottom;
-  transition: all 1s ease-out;
+  transition: background-position 1s ease-out;
 }
 
 a.rainbow.purple,
@@ -102,7 +102,7 @@ button.rainbow.purple {
   );
   background-size: 20000% 100%;
   background-position: right bottom;
-  transition: all 1s ease-out;
+  transition: background-position 1s ease-out;
 }
 
 a.rainbow.pink,
@@ -118,7 +118,7 @@ button.rainbow.pink {
   );
   background-size: 20000% 100%;
   background-position: right bottom;
-  transition: all 1s ease-out;
+  transition: background-position 1s ease-out;
 }
 
 a.rainbow.cyan,
@@ -134,7 +134,7 @@ button.rainbow.cyan {
   );
   background-size: 20000% 100%;
   background-position: right bottom;
-  transition: all 1s ease-out;
+  transition: background-position 1s ease-out;
 }
 
 .rainbow.red:hover,
@@ -143,5 +143,5 @@ button.rainbow.cyan {
 .rainbow.pink:hover,
 .rainbow.cyan:hover {
   background-position: left bottom;
-  transition: all 4s ease-out;
+  transition: background-position 4s ease-out;
 }

--- a/src/components/CollapsableDescription.module.css
+++ b/src/components/CollapsableDescription.module.css
@@ -8,7 +8,6 @@
 
 .showButton {
   cursor: pointer;
-  font-size: var(--maru-small);
   color: var(--mid-gray);
   text-decoration: underline;
 }

--- a/src/components/GuideCard.js
+++ b/src/components/GuideCard.js
@@ -19,31 +19,36 @@ const GuideCard = ({
 }) => {
   return (
     <article className={cn(css.root, css[variant])}>
-      <div className={css.block}>
-        <div className={css.top}>
-          <div className={css.icon}>{icon}</div>
-          <h2>
-            {link ? <a href={link}>{title}</a> : <Link to={slug}>{title}</Link>}
-          </h2>
+      <div className={css.top}>
+        <div className={css.icon}>{icon}</div>
+        <h2>
+          {link ? <a href={link}>{title}</a> : <Link to={slug}>{title}</Link>}
+        </h2>
+      </div>
+      <div className={css.bottom}>
+        <div className={css.left}>
+          <p className={css.description}>{description}</p>
+          <ButtonPanel
+            className={css.meta}
+            text={meta}
+            buttonLink={link ?? slug}
+            buttonText="Read"
+            variant={variant}
+            rainbow
+          />
         </div>
-        <div className={css.bottom}>
-          <div className={css.left}>
-            <p className={css.description}>{description}</p>
-            <ButtonPanel
-              className={css.meta}
-              text={meta}
-              buttonLink={link ?? slug}
-              buttonText="Read"
-              variant={variant}
-              rainbow
-            />
-          </div>
-          <div className={css.right}>
-            <Image image={image} imgClassName={css.img} />
-          </div>
+        <div className={css.right}>
+          <Image image={image} imgClassName={css.img} />
+          <ButtonPanel
+            className={css.meta}
+            text={meta}
+            buttonLink={link ?? slug}
+            buttonText="Read"
+            variant={variant}
+            rainbow
+          />
         </div>
       </div>
-      <div className={css.gap} />
     </article>
   );
 };

--- a/src/components/GuideCard.module.css
+++ b/src/components/GuideCard.module.css
@@ -1,20 +1,13 @@
 .root {
-  flex-basis: 50%;
-  width: 50%;
+  flex-basis: calc(50% - var(--baseline) / 2);
+  width: calc(50% - var(--baseline) / 2);
 
   display: flex;
+  flex-direction: column;
 
   @media (--medium) {
     width: 100%;
     flex-basis: 100%;
-  }
-}
-
-.root:nth-child(odd):last-child {
-  width: 100%;
-  flex-basis: 100%;
-  & .gap {
-    border: none !important;
   }
 }
 
@@ -43,72 +36,14 @@
   --background-color: var(--cyan-light);
 }
 
-.block {
-  width: calc(100% - var(--baseline-box));
-}
-
-@media (--medium) {
-  .block {
-    width: 100%;
-  }
-}
-/* GAP */
-.gap {
-  flex: 0 0 var(--baseline-box);
-
-  @media (--medium) {
-    display: none;
-  }
-}
-
-.root:nth-child(odd) .gap {
-  margin-top: var(--baseline-box);
-  border-top: var(--border);
-}
-
-.root:nth-child(even) .gap {
-  border-left: var(--border);
-  margin-left: -1px;
-}
-
-.top,
-.meta {
-  border-top: var(--border);
-}
-
-.right,
-.root:nth-child(odd),
-.root:nth-child(even) .top,
-.root:nth-child(even) .bottom {
-  border-left: var(--border);
-}
-
-@media (--medium) {
-  .root {
-    border-left: var(--border);
-  }
-  .root:nth-child(n) .top,
-  .root:nth-child(n) .bottom {
-    border-left: none;
-  }
-}
-
-.top,
-.left,
-.right,
-.root:nth-child(odd) .gap {
-  border-bottom: var(--border);
-}
-
-.top,
-.bottom,
 .icon {
   border-right: var(--border);
+  border-bottom: var(--border);
+  border-left: var(--border);
 }
 
 .top {
-  margin-top: var(--baseline-box);
-  height: calc(var(--baseline) + 1px);
+  height: var(--baseline);
   display: flex;
   align-items: center;
 }
@@ -119,18 +54,20 @@
   height: var(--baseline);
   flex: 0 0 var(--baseline);
 
-  line-height: 1;
+  color: var(--color);
   display: flex;
   justify-content: center;
   align-items: center;
-  padding-bottom: calc(var(--baseline-box) / 15);
 }
 
 .top h2 {
-  margin-left: var(--spacing-normal);
+  flex-grow: 1;
+  padding-left: var(--spacing-normal);
+  border-bottom: var(--border);
+  height: var(--baseline);
+  line-height: var(--baseline);
   font-size: var(--maru-medium);
   font-family: var(--maru);
-  font-weight: bold;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -141,10 +78,11 @@
 }
 
 .left {
-  flex: 1 1 60%;
+  flex: 1 1 40%;
   display: flex;
   flex-direction: column;
 }
+
 .description {
   margin: 0;
   font-family: var(--maru-mono);
@@ -152,37 +90,71 @@
   padding: var(--spacing-small) var(--spacing-small) var(--spacing-small)
     var(--spacing-normal);
   flex-grow: 1;
-  max-height: var(--baseline-box-4x);
   overflow: hidden;
   text-overflow: ellipsis;
+  border-bottom: var(--border);
+  border-left: var(--border);
 }
-.meta {
-  border-bottom: none;
-  border-left: none;
+
+.left .meta {
+  display: none;
 }
 
 .right {
-  flex: 1 1 40%;
+  flex: 1 1 60%;
+}
+
+.meta {
+  height: var(--baseline);
 }
 
 .img {
+  border-bottom: var(--border);
+  border-left: var(--border);
   width: 100%;
-  height: var(--baseline-box-3x);
+  height: var(--baseline-4x);
   object-fit: cover;
 }
 
-@media (--small) {
+@media (--medium) {
+  .left .meta {
+    display: flex;
+  }
+
+  .right .meta {
+    display: none;
+  }
+
+  .img {
+    height: var(--baseline-5x);
+  }
+}
+
+@media (--reduced) {
   .bottom {
     flex-direction: column-reverse;
   }
 
+  .img {
+    height: var(--baseline-7x);
+  }
+
+  .description {
+    height: var(--baseline-3x);
+  }
+}
+
+@media (--small) {
   .left {
     flex-basis: var(--baseline-box-3x);
   }
   .right {
     flex-basis: var(--baseline-box-5x);
   }
+}
+
+@media (--xsmall) {
   .img {
-    height: var(--baseline-box-5x);
+    height: var(--baseline-box-8x);
   }
 }

--- a/src/components/Tags.js
+++ b/src/components/Tags.js
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useState } from 'react';
 import { Link } from 'gatsby';
 import cn from 'classnames';
 
@@ -6,13 +6,13 @@ import * as css from './Tags.module.css';
 
 const Tags = memo(
   ({ className, heading, items, singleLine = true, linkTo }) => {
-    // const visibleItems = items.slice(0, 2);
-    // const hiddenItems = items.slice(2);
+    const [showAll, setShowAll] = useState(false);
+    const visibleItems = showAll ? items : items.slice(0, 2);
     return (
       <div
         className={cn(css.root, className, { [css.singleLine]: singleLine })}>
         <h4 className={css.tagHeading}>{heading}</h4>
-        {items.map((tag) =>
+        {visibleItems.map((tag, index) =>
           linkTo ? (
             <Link
               key={tag}
@@ -20,12 +20,22 @@ const Tags = memo(
               to={linkTo(tag)}
               state={{ expanded: true }}>
               {tag}
+              {index !== items.length - 1 && ','}
             </Link>
           ) : (
             <span className={css.tag} key={tag}>
               {tag}
+              {index !== items.length - 1 && ','}
             </span>
           )
+        )}
+
+        {items.length > 2 && !showAll && (
+          <button
+            className={css.showButton}
+            onClick={() => setShowAll((v) => !v)}>
+            Show {showAll ? 'less' : 'more'}
+          </button>
         )}
       </div>
     );

--- a/src/components/Tags.module.css
+++ b/src/components/Tags.module.css
@@ -12,6 +12,7 @@
 
 .tag {
   font-family: var(--maru-mono);
+  display: inline-block;
 }
 
 .singleLine {
@@ -29,4 +30,21 @@
   .tags {
     display: none;
   }
+}
+
+.showButton {
+  cursor: pointer;
+  font-size: inherit;
+  color: var(--mid-gray);
+  text-decoration: underline;
+}
+
+/* Variant */
+
+.red .showButton {
+  color: var(--red);
+}
+
+.cyan .showButton {
+  color: var(--cyan);
 }

--- a/src/components/VideoCard.js
+++ b/src/components/VideoCard.js
@@ -52,6 +52,17 @@ const VideoCard = ({
           </div>
           <div className={css.right}>
             <Image image={image} imgClassName={css.img} />
+            {link ? (
+              <a className={css.meta} href={link}>
+                <span>{meta}</span>
+                <Play className={css.play} />
+              </a>
+            ) : (
+              <Link to={slug} className={css.meta}>
+                <span>{meta}</span>
+                <Play className={css.play} />
+              </Link>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/VideoCard.module.css
+++ b/src/components/VideoCard.module.css
@@ -130,6 +130,12 @@
   border-right: var(--border);
 }
 
+@media (--medium) {
+  .top, .bottom {
+    border-right: none;
+  }
+}
+
 .top {
   margin-top: var(--baseline-box);
   height: calc(var(--baseline) + 1px);
@@ -167,6 +173,11 @@
   display: flex;
   flex-direction: column;
 }
+
+.left .meta {
+  display: none;
+}
+
 .description {
   margin: 0;
   font-family: var(--maru-mono);
@@ -178,6 +189,14 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.right {
+  flex: 1 1;
+  display: flex;
+  flex-direction: column;
+}
+
+
 .meta {
   margin-top: 0;
   height: var(--baseline);
@@ -191,25 +210,52 @@
   justify-content: space-between;
 }
 
+.img {
+  width: 100%;
+  height: var(--baseline-box-4x);
+  object-fit: cover;
+}
+
+
 @media (--medium) {
   .play {
     width: 28px;
     height: 28px;
   }
+
+  .left {
+    flex: 1.5 1;
+  }
+
+  .img {
+    height: var(--baseline-box-5x);
+  }
+
+  .left .meta {
+    display: flex;
+  }
+
+  .right .meta {
+    display: none;
+  }
 }
 
-.right {
-  flex-basis: var(--baseline-5x);
+@media(--reduced) {
+  .bottom {
+    flex-direction: column-reverse;
+  }
+
+  .description {
+    height: var(--baseline-4x);
+  }
+
+  .img {
+    height: var(--baseline-box-7x);
+  }
 }
 
-.img {
-  width: 100%;
-  height: var(--baseline-box-5x);
-  object-fit: cover;
-}
-
-@media (--small) {
-  /* .bottom {
-    flex-direction: ;
-  } */
+@media (--xsmall) {
+  .img {
+    height: var(--baseline-box-8x);
+  }
 }

--- a/src/components/tracks/Card.js
+++ b/src/components/tracks/Card.js
@@ -81,8 +81,18 @@ const Card = ({
         <div className={css.left}>
           <div className={css.text}>
             <h3 className={css.title}>{title}</h3>
-            <Tags className={css.tags} heading="Topics" items={topics} />
-            <Tags className={css.tags} heading="Languages" items={languages} />
+            <Tags
+              className={css.tags}
+              heading="Languages"
+              items={languages}
+              linkTo={(value) => `/tracks/lang:${value}+topic:all`}
+            />
+            <Tags
+              className={css.tags}
+              heading="Topics"
+              items={topics}
+              linkTo={(value) => `/tracks/lang:all+topic:${value}`}
+            />
             <p className={css.description}>{description}</p>
           </div>
           <div className={css.fadeText} />

--- a/src/components/tracks/Header.js
+++ b/src/components/tracks/Header.js
@@ -20,18 +20,6 @@ const Header = ({ track }) => {
         />
         <div className={css.tagsContainer}>
           <Tags
-            heading="Languages"
-            items={languages}
-            singleLine={false}
-            linkTo={(value) => `/tracks/lang:${value}+topic:all`}
-          />
-          <Tags
-            heading="Topics"
-            items={topics}
-            singleLine={false}
-            linkTo={(value) => `/tracks/lang:all+topic:${value}`}
-          />
-          <Tags
             heading={track.type === 'main' ? 'Main track' : 'Side track'}
             items={[
               ...(track.chapters
@@ -44,6 +32,18 @@ const Header = ({ track }) => {
               `${numVideos} videos`
             ]}
             singleLine={false}
+          />
+          <Tags
+            heading="Languages"
+            items={languages}
+            singleLine={false}
+            linkTo={(value) => `/tracks/lang:${value}+topic:all`}
+          />
+          <Tags
+            heading="Topics"
+            items={topics}
+            singleLine={false}
+            linkTo={(value) => `/tracks/lang:all+topic:${value}`}
           />
         </div>
       </div>

--- a/src/components/tracks/Header.module.css
+++ b/src/components/tracks/Header.module.css
@@ -52,6 +52,7 @@
   margin-top: var(--baseline-3of5);
   margin-bottom: var(--baseline-2of5);
   height: var(--baseline-box-4x);
+  overflow-y: auto;
   padding: 0 var(--box-padding);
   background: white;
   font-size: var(--maru-medium);

--- a/src/pages/guides.js
+++ b/src/pages/guides.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { graphql } from 'gatsby';
+import cn from 'classnames';
 
 import Layout from '../components/Layout';
 import CharacterSpacer from '../components/CharacterSpacer';
@@ -50,22 +51,39 @@ const GuidesPage = ({ data }) => {
         Character={DotCharacter2}
       />
 
+      <Spacer className={css.spacer} />
+
       <div className={css.guideList}>
         {guides.map((guide, i) => (
-          <GuideCard
-            key={i}
-            title={guide.mdx.frontmatter.title}
-            description={guide.mdx.frontmatter.description}
-            slug={`/guides/${guide.mdx.slug}`}
-            meta={guide.mdx.frontmatter.date}
-            icon={'📒'}
-            image={
-              guide.cover?.file?.childImageSharp?.gatsbyImageData ??
-              guidesPlaceholderImage
-            }
-            variant="purple"
-            className={css.guideItem}
-          />
+          <>
+            <GuideCard
+              key={i}
+              title={guide.mdx.frontmatter.title}
+              description={guide.mdx.frontmatter.description}
+              slug={`/guides/${guide.mdx.slug}`}
+              meta={guide.mdx.frontmatter.date}
+              icon={'📒'}
+              image={
+                guide.cover?.file?.childImageSharp?.gatsbyImageData ??
+                guidesPlaceholderImage
+              }
+              variant="purple"
+            />
+            {i % 2 === 0 && (
+              <div
+                className={cn(css.horizontalGap, {
+                  [css.lastHG]: i === guides.length - 1
+                })}
+              />
+            )}
+            {i !== guides.length - 1 && (
+              <div
+                className={cn(css.verticalGap, {
+                  [css.rowVG]: i % 2 !== 0
+                })}
+              />
+            )}
+          </>
         ))}
       </div>
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -58,7 +58,7 @@ const ChallengeCard = ({ challenge, placeholderImage }) => {
         <div className={css.icon}>👁</div>
 
         <h3 className={css.smallTitle}>
-          <Link to={`tracks/${slug}`}>
+          <Link to={`challenge/${slug}`}>
             {videoNumber ? `#${videoNumber} — ` : ''} {title}
           </Link>
         </h3>

--- a/src/styles/pages/guides.module.css
+++ b/src/styles/pages/guides.module.css
@@ -52,21 +52,37 @@
 
 .guideList {
   display: flex;
-  justify-content: center;
-  align-items: center;
   flex-wrap: wrap;
 }
 
-.guideItem {
-  flex: 50%;
-  /* display: flex;
-  justify-content: start;
-  align-items: center;
-  border-bottom: var(--border-purple);
+/* GAP */
+.horizontalGap {
+  flex: 0 0 var(--baseline-box);
   border-left: var(--border-purple);
+  border-bottom: var(--border-purple);
+
+  @media (--medium) {
+    display: none;
+  }
+}
+
+.lastHG {
+  flex-grow: 1;
+}
+
+.verticalGap {
+  flex: 0 0 100%;
   width: 100%;
   height: var(--baseline);
-  padding: 0 var(--box-padding);
-  background: var(--purple-light);
-  color: var(--gray-mid); */
+  border-left: var(--border-purple);
+  border-bottom: var(--border-purple);
+  display: none;
+
+  @media (--medium) {
+    display: block;
+  }
+}
+
+.rowVG {
+  display: block;
 }

--- a/src/styles/pages/index.module.css
+++ b/src/styles/pages/index.module.css
@@ -113,11 +113,11 @@
 }
 
 .trackCard {
-  flex: calc(50% - var(--baseline) / 2);
+  width: calc(50% - var(--baseline) / 2);
 }
 
 .challengeCard {
-  flex: calc((100% - 2 * var(--baseline)) / 3);
+  width: calc((100% - 2 * var(--baseline)) / 3);
 }
 
 .card .details {
@@ -414,7 +414,8 @@
     display: block;
   }
 
-  .trackCard {
+  .trackCard,
+  .challengeCard {
     flex: 100%;
   }
 


### PR DESCRIPTION
This PR fixes a couple issues noticed by @shiffman and me:
- #132 : Added a "show more" button for long tag lists, left the track header section overflow when expanded, and moved around some sections.
- #129 : Made the thumbnail layout consistent to challenges cards, and made a similar fix to guide cards.
- Buttons had CSS transitions setup to all CSS properties, which made them animate unintentionally when resizing the page. This fixes that behavior and leaves the transition to the intentional background animation.
- Fixed a little URL issue when clicking the titles in challenges cards in homepage. It was trying to go to tracks/ instead of challenge/