### PR TITLE
Update passenger-showcase-guide.md

### DIFF
--- a/content/pages/guides/passenger-showcase-guide.md
+++ b/content/pages/guides/passenger-showcase-guide.md
@@ -21,11 +21,11 @@ If the video is a part of a series, chances are it is either in a main or side t
 
 ## Creating the contribution file
 
-Once in the `showcase` folder of the video, click "Add file" in the upper right-hand corner and click "Create new file" (or "Upload files'', if you already have the contribution on your local machine).
+If someone has already submitted a contribution. you will see a `showcase` folder.  Click "Add file" in the upper right-hand corner and click "Create new file" (or "Upload files'', if you already have the contribution on your local machine).  Name the file `contribution2.json`, if that exists `contribution3.json`, etc).  If there are no submissions yet, name the file `showcase/contribution1.json`.  
 
 ![Creating a new file in the showcases folder](./passenger-showcase/showcasefolder.png)
 
-Name the file `contribution1.json` (or if the file already exists, `contribution2.json`, if that exists `contribution3.json`, etc).
+
 
 Copy the template into the new file:
 


### PR DESCRIPTION
When there are no contributions yet, there will not be a "showcase" folder.  I have edited the guide to clarify that the file name will need to include the showcase folder name for the first contribution.