### PR TITLE
Create a section in "Maintaining the Website" Guide to address adding events

### DIFF
--- a/content/pages/guides/mantain-website-guide.md
+++ b/content/pages/guides/mantain-website-guide.md
@@ -390,6 +390,36 @@ You can add as many custom sections with as many links as you want. Just a side 
 
 ---
 
+A new Coding Train event has been announced and you want to add it to the website so everyone else can find it there? OK, just follow these steps:
+
+## Adding a New Event
+---
+If you'd like to an event to the Coding Train homepage you will need to edit the `content/pages/homepage/index.json` file. By adding a new event object to the `events` object's array of `"upcoming"` events. Note, if there are currently no upcoming events then `"upcoming"` will be an empty array like `"upcoming": []`.
+
+```json
+  "upcoming": [{
+        "title": "Neuroevolution - the Nature of Code",
+        "description": "Watch as Dan steps through each of these fun challenges, then put your new knowledge to work and create your own projects.",
+        "date": "2022-07-16",
+        "time": "20:00",
+        "host": "dan Shiffman",
+        "type": "Livestream",
+        "url": "https://www.youtube.com/channel/UCvjgXvBlbQiydffZU7m1_aw"
+  }]
+```
+
+Now let's take a closer look at each property:
+
+| Property         | Description                                                | Example            |
+| ---------------- | ---------------------------------------------------------- | ------------------ |
+| `title`          |Official event title             | `"Neuroevolution - the Nature of Code"` |
+| `date`           | The scheduled date for the event  | `2022-07-16`       |
+| `time`       | The schedule time for the event    | `"20:00"`      |
+| `host`     | Path to the corresponding code files inside the repository | "dan Shiffman",  |
+| `type`   | Is the event in person? online?    | `irl/livestream...`  |
+| `url`     | Website where can attendees register or attend event.      | `https://www.youtube.com/channel/UCvjgXvBlbQiydffZU7m1_aw`        |
+
+
 ## Appendix A: Links within markdown files to other markdown files
 
 If you want to link to another page from within a markdown file, you have to use the following snippet:


### PR DESCRIPTION
- This pull request addresses https://github.com/CodingTrain/thecodingtrain.com/issues/148 in order to add some instructions to help folks figure out how to add upcoming events to The Coding Train Website.
- I tried to model the documentation based off of the other information available in the guide. I wasn't sure where this instruction should fit in the hierarchy of the guide.

<img width="1728" alt="Screen Shot 2022-06-04 at 3 28 04 PM" src="https://user-images.githubusercontent.com/6998954/172022807-9720ecf3-bcb1-40be-add7-c314c94d9537.png">

