### PR TITLE
Address Formatting Issues in "Maintaining the Website" Guide

### DIFF
--- a/content/pages/guides/mantain-website-guide.md
+++ b/content/pages/guides/mantain-website-guide.md
@@ -100,10 +100,11 @@ Copy the template into the `index.json` file and fill out the track information.
   ]
 }
 ```
+<br/>
 
+```
 $ bundle exec jekyll serve
-
-````
+```
 
 This command doesn't finish by itself like the others did. Instead, it
 instructs Jekyll to watch all your project files for changes and
@@ -248,7 +249,7 @@ npm run lint
 
 If you've made it to here then you should be all set to make a pull request. Thanks for all your help with the Coding Train website!
 
-# Ex content contribution guide
+## Ex content contribution guide
 
 You want to help with integrating new content into the repository? Great to hear that! Now let's see how you can help:
 


### PR DESCRIPTION
- update hierarchy of `ex-contributor guide` to `h2` instead of `h1` ensure that all page headings are on the same level and the table of contents will now display multiple sections(that all have `h2`) instead of `ex-contributor guide` which has a higher hierarchy than the rest. 
- Update page to ensure that page formatting continues to work after the jekyll command. I added a `<br/>` and removed an extra backtick. I thought the space was necessary to ensure that the jekyll command appeared distinct from the code snippet right above it.

| Before  |  After |
|---|---|
| Before (Table of Contents only contains 1 item): <img width="1572" alt="Screen Shot 2022-06-04 at 3 32 48 PM" src="https://user-images.githubusercontent.com/6998954/172023131-a51038ff-8580-4f19-9b40-80e873a9f312.png">  |  After (Table of Contents contains multiple items): <img width="1574" alt="Screen Shot 2022-06-04 at 3 33 01 PM" src="https://user-images.githubusercontent.com/6998954/172023132-58b540bf-0cb5-4048-9536-9f7135c0bd83.png">
|Before (Formatting of Page remains in code format after jekyll command)<img width="1577" alt="Screen Shot 2022-06-04 at 3 36 14 PM" src="https://user-images.githubusercontent.com/6998954/172023134-4625ab9a-d4fc-4d56-9981-b93b17005df7.png">|After (Formatting of Page reverts to regular text after jekyll command)<img width="1581" alt="Screen Shot 2022-06-04 at 3 36 00 PM" src="https://user-images.githubusercontent.com/6998954/172023133-beb51476-17da-4742-b846-b572572d2177.png">
   |   |





