### PR TITLE
fix: allows subfolders inside of guides and about content folders

### DIFF
--- a/content-testing/content-structure.js
+++ b/content-testing/content-structure.js
@@ -259,14 +259,14 @@ const contentStructure = {
           folders: {},
           files: {},
           isFileSensitive: false,
-          isFolderSensitive: true,
+          isFolderSensitive: false,
           isRequired: true
         },
         about: {
           folders: {},
           files: {},
           isFileSensitive: false,
-          isFolderSensitive: true,
+          isFolderSensitive: false,
           isRequired: true
         },
         tracks: {


### PR DESCRIPTION
Little fix to [comment](https://github.com/CodingTrain/thecodingtrain.com/issues/44#issuecomment-1146672822) that allows subfolders in `content/pages/guides`, and also `content/pages/about` because it seemed appropriate.