### PR TITLE
fix: sublists don't have left border

### DIFF
--- a/src/templates/guide.module.css
+++ b/src/templates/guide.module.css
@@ -107,10 +107,13 @@
     border-left: none;
     padding: 0 0 var(--box-padding) 0;
   }
+
+  & .list {
+    border-left: none;
+  }
 }
 
 .listItem {
-  /* padding-left: var(--box-padding); */
   font-size: var(--maru-medium);
   line-height: var(--maru-medium-line-height);
 }


### PR DESCRIPTION
I noticed in the new guides a little style bug, lists get a left border, even when they are nested:
<img width="468" alt="Screen Shot 2022-06-04 at 21 23 11" src="https://user-images.githubusercontent.com/13511560/172030976-0aa28ccf-48d8-490b-a150-266063e6406f.png">

This PR fixes that:
<img width="431" alt="Screen Shot 2022-06-04 at 21 23 32" src="https://user-images.githubusercontent.com/13511560/172030981-2e3d730a-f627-47e1-8252-1bc8c6461271.png">

