### PR TITLE
Add 'Linking Code Examples' in Site Maintanence Guide

### DIFF
--- a/content/pages/guides/mantain-website-guide.md
+++ b/content/pages/guides/mantain-website-guide.md
@@ -111,8 +111,8 @@ In the `index.json` file of a challenge, the `codeExamples` field contains the c
 
 The URLs of the code examples should ideally be in the following format:
 
-| Language | Description                     | Example                                                  |
-| -------- | ------------------------------- | -------------------------------------------------------- |
+| Language | Description | Example |
+| -------- | ----------- | ------- |
 | `p5`     | Link to p5.js Web Editor sketch | `https://editor.p5js.org/codingtrain/sketches/pLW3_PNDM` |
 | `p5`, `processing`, `other`     | Link to code example on GitHub (from the [Coding Challenges repo](https://github.com/CodingTrain/Coding-Challenges/)) | `https://github.com/CodingTrain/Coding-Challenges/tree/main/169_Pi_Day/p5` |
 

--- a/content/pages/guides/mantain-website-guide.md
+++ b/content/pages/guides/mantain-website-guide.md
@@ -189,6 +189,6 @@ Now let's take a closer look at each property:
 | `title`  | Official event title                                  | `"Neuroevolution - the Nature of Code"`                    |
 | `date`   | The scheduled date for the event                      | `2022-07-16`                                               |
 | `time`   | The schedule time for the event                       | `"20:00"`                                                  |
-| `host`   | Host of the event                                     | "dan Shiffman",                                            |
+| `host`   | Host of the event                                     | "Coding Train",                                            |
 | `type`   | Is the event in person? online?                       | `irl/livestream...`                                        |
 | `url`    | Website where can attendees register or attend event. | `https://www.youtube.com/channel/UCvjgXvBlbQiydffZU7m1_aw` |

--- a/content/pages/guides/mantain-website-guide.md
+++ b/content/pages/guides/mantain-website-guide.md
@@ -16,7 +16,7 @@ Then copy the template into the `index.json`
 
 ```json
 {
-  "title": "Video title",  
+  "title": "Video title",
   "description": "Video description",
   "videoNumber": "Video number",
   "videoId": "YouTube video ID",
@@ -101,14 +101,6 @@ In the `index.json` file of a challenge, the `codeExamples` field contains the c
       "urls": {
         "p5": "url to p5 editor or code",
         "processing": "url to processing sketch",
-        "other": "url to other source, like GitHub"
-      }
-    },
-    {
-      "title": "Code example 2 title",
-      "description": "Code example 2 description",
-      "image": "image2.png",
-      "urls": {
         "other": "url to other source, like GitHub"
       }
     }

--- a/content/pages/guides/mantain-website-guide.md
+++ b/content/pages/guides/mantain-website-guide.md
@@ -16,7 +16,7 @@ Then copy the template into the `index.json`
 
 ```json
 {
-  "title": "Video title",
+  "title": "Video title",  
   "description": "Video description",
   "videoNumber": "Video number",
   "videoId": "YouTube video ID",
@@ -51,7 +51,22 @@ Then copy the template into the `index.json`
   ],
   "groupLinks": [
     {
-      "title": "Group of links title",
+      "title": "Videos",
+      "links": [
+        {
+          "title": "Link 1 title",
+          "url": "link 1 url",
+          "description": "description of content linked"
+        },
+        {
+          "title": "Link 2 title",
+          "url": "link 2 url",
+          "description": "description of content linked"
+        }
+      ]
+    }, 
+    {
+      "title": "References",
       "links": [
         {
           "title": "Link 1 title",
@@ -70,6 +85,49 @@ Then copy the template into the `index.json`
 ```
 
 For the `groupLinks` section, links to videos should be put in a `Videos` group. Links to other pages, such as Wikipedia articles, blog posts, and documentation entries should be put in a `References` group.
+
+## Coding Challenges - linking to code examples
+
+In the `index.json` file of a challenge, the `codeExamples` field contains the code examples displayed below the video.
+
+```jsonc
+{
+  // ...
+  "codeExamples": [
+    {
+      "title": "Code example 1 title",
+      "description": "Code example 1 description",
+      "image": "image1.png",
+      "urls": {
+        "p5": "url to p5 editor or code",
+        "processing": "url to processing sketch",
+        "other": "url to other source, like GitHub"
+      }
+    },
+    {
+      "title": "Code example 2 title",
+      "description": "Code example 2 description",
+      "image": "image2.png",
+      "urls": {
+        "other": "url to other source, like GitHub"
+      }
+    }
+  ],
+  // ...
+}
+```
+
+The URLs of the code examples should ideally be in the following format:
+
+| Language | Description                     | Example                                                  |
+| -------- | ------------------------------- | -------------------------------------------------------- |
+| `p5`     | Link to p5.js Web Editor sketch | `https://editor.p5js.org/codingtrain/sketches/pLW3_PNDM` |
+| `p5`, `processing`, `other`     | Link to code example on GitHub (from the [Coding Challenges repo](https://github.com/CodingTrain/Coding-Challenges/)) | `https://github.com/CodingTrain/Coding-Challenges/tree/main/169_Pi_Day/p5` |
+
+
+
+To add thumbnail images for the code examples (the output of the code), the images should be inside a subfolder named `images` in the challenge folder.
+
 
 ## Tracks - adding template & video folder
 
@@ -134,11 +192,11 @@ If you'd like to an event to the Coding Train homepage you will need to edit the
 
 Now let's take a closer look at each property:
 
-| Property | Description                                                | Example                                                    |
-| -------- | ---------------------------------------------------------- | ---------------------------------------------------------- |
-| `title`  | Official event title                                       | `"Neuroevolution - the Nature of Code"`                    |
-| `date`   | The scheduled date for the event                           | `2022-07-16`                                               |
-| `time`   | The schedule time for the event                            | `"20:00"`                                                  |
-| `host`   | Path to the corresponding code files inside the repository | "dan Shiffman",                                            |
-| `type`   | Is the event in person? online?                            | `irl/livestream...`                                        |
-| `url`    | Website where can attendees register or attend event.      | `https://www.youtube.com/channel/UCvjgXvBlbQiydffZU7m1_aw` |
+| Property | Description                                           | Example                                                    |
+| -------- | ----------------------------------------------------- | ---------------------------------------------------------- |
+| `title`  | Official event title                                  | `"Neuroevolution - the Nature of Code"`                    |
+| `date`   | The scheduled date for the event                      | `2022-07-16`                                               |
+| `time`   | The schedule time for the event                       | `"20:00"`                                                  |
+| `host`   | Host of the event                                     | "dan Shiffman",                                            |
+| `type`   | Is the event in person? online?                       | `irl/livestream...`                                        |
+| `url`    | Website where can attendees register or attend event. | `https://www.youtube.com/channel/UCvjgXvBlbQiydffZU7m1_aw` |


### PR DESCRIPTION
- Added a "Linking Code Examples" section in the Website Maintainence Guide.

If you feel that something is missing and/or something else needs to be added here, please let me know.

(do you think changes from the earlier system of `CodingTrain/website` needs to be mentioned?) 