### PR TITLE
Meta images

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,7 +1,9 @@
 module.exports = {
   siteMetadata: {
     siteUrl: 'https://www.thecodingtrain.com',
-    title: 'The Coding Train'
+    title: 'The Coding Train',
+    description:
+      'All aboard the Coding Train with Daniel Shiffman, a YouTube channel dedicated to beginner-friendly creative coding tutorials and challenges.'
   },
   flags: {
     DEV_SSR: true

--- a/src/components/Head.js
+++ b/src/components/Head.js
@@ -2,14 +2,16 @@ import React, { memo } from 'react';
 import { Helmet } from 'react-helmet';
 import { useStaticQuery, graphql } from 'gatsby';
 
-const URL = 'https://thecodingtrain.com/';
-const defaultTitle = 'The Coding Train';
-const defaultDescription =
-  'All aboard the Coding Train with Daniel Shiffman, a YouTube channel dedicated to beginner-friendly creative coding tutorials and challenges.';
-
 const Head = ({ title, description }) => {
   const data = useStaticQuery(graphql`
     query {
+      site {
+        siteMetadata {
+          title
+          siteUrl
+          description
+        }
+      }
       coverImage: allFile(
         filter: {
           name: { eq: "placeholder" }
@@ -25,6 +27,15 @@ const Head = ({ title, description }) => {
       }
     }
   `);
+  const {
+    site: {
+      sitMetadata: {
+        title: defaultTitle,
+        siteURL,
+        description: defaultDescription
+      }
+    }
+  } = data;
   const image =
     data.coverImage.nodes[0].childImageSharp.gatsbyImageData.images.fallback
       .src;
@@ -42,22 +53,22 @@ const Head = ({ title, description }) => {
       <meta name="description" content={description ?? defaultDescription} />
 
       <meta property="og:type" content="website" />
-      <meta property="og:url" content={URL} />
+      <meta property="og:url" content={siteURL} />
       <meta property="og:title" content={title ?? defaultTitle} />
       <meta
         property="og:description"
         content={description ?? defaultDescription}
       />
-      <meta property="og:image" content={image} />
+      <meta property="og:image" content={`${siteURL}${image.slice(1)}`} />
 
       <meta property="twitter:card" content="summary_large_image" />
-      <meta property="twitter:url" content={URL} />
+      <meta property="twitter:url" content={siteURL} />
       <meta property="twitter:title" content={title ?? defaultTitle} />
       <meta
         property="twitter:description"
         content={description ?? defaultDescription}
       />
-      <meta property="twitter:image" content={image} />
+      <meta property="twitter:image" content={`${siteURL}${image.slice(1)}`} />
     </Helmet>
   );
 };

--- a/src/components/Head.js
+++ b/src/components/Head.js
@@ -1,24 +1,63 @@
 import React, { memo } from 'react';
 import { Helmet } from 'react-helmet';
+import { useStaticQuery, graphql } from 'gatsby';
+
+const URL = 'https://thecodingtrain.com/';
+const defaultTitle = 'The Coding Train';
+const defaultDescription =
+  'All aboard the Coding Train with Daniel Shiffman, a YouTube channel dedicated to beginner-friendly creative coding tutorials and challenges.';
 
 const Head = ({ title, description }) => {
+  const data = useStaticQuery(graphql`
+    query {
+      coverImage: allFile(
+        filter: {
+          name: { eq: "placeholder" }
+          sourceInstanceName: { eq: "main-tracks" }
+          extension: { in: ["jpg", "png"] }
+        }
+      ) {
+        nodes {
+          childImageSharp {
+            gatsbyImageData
+          }
+        }
+      }
+    }
+  `);
+  const image =
+    data.coverImage.nodes[0].childImageSharp.gatsbyImageData.images.fallback
+      .src;
+  // console.log({ image });
   return (
     <Helmet
       htmlAttributes={{
         lang: 'en'
       }}
-      defaultTitle="The Coding Train"
-      titleTemplate="%s / The Coding Train">
+      defaultTitle={defaultTitle}
+      titleTemplate={`%s / ${defaultTitle}`}>
       <meta charSet="utf-8" />
       <meta name="viewport" content="width=device-width,initial-scale=1" />
       <title>{title}</title>
+      <meta name="description" content={description ?? defaultDescription} />
+
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content={URL} />
+      <meta property="og:title" content={title ?? defaultTitle} />
       <meta
-        name="description"
-        content={
-          description ??
-          'All aboard the Coding Train with Daniel Shiffman, a YouTube channel dedicated to beginner-friendly creative coding tutorials and challenges.'
-        }
+        property="og:description"
+        content={description ?? defaultDescription}
       />
+      <meta property="og:image" content={image} />
+
+      <meta property="twitter:card" content="summary_large_image" />
+      <meta property="twitter:url" content={URL} />
+      <meta property="twitter:title" content={title ?? defaultTitle} />
+      <meta
+        property="twitter:description"
+        content={description ?? defaultDescription}
+      />
+      <meta property="twitter:image" content={image} />
     </Helmet>
   );
 };

--- a/src/components/Head.js
+++ b/src/components/Head.js
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 import { Helmet } from 'react-helmet';
 import { useStaticQuery, graphql } from 'gatsby';
 
-const Head = ({ title, description }) => {
+const Head = ({ title, description, image }) => {
   const data = useStaticQuery(graphql`
     query {
       site {
@@ -27,19 +27,19 @@ const Head = ({ title, description }) => {
       }
     }
   `);
+
   const {
     site: {
-      sitMetadata: {
+      siteMetadata: {
         title: defaultTitle,
-        siteURL,
+        siteUrl,
         description: defaultDescription
       }
     }
   } = data;
-  const image =
-    data.coverImage.nodes[0].childImageSharp.gatsbyImageData.images.fallback
-      .src;
-  // console.log({ image });
+  const metaImage = (
+    image ?? data.coverImage.nodes[0].childImageSharp.gatsbyImageData
+  ).images.fallback.src;
   return (
     <Helmet
       htmlAttributes={{
@@ -53,22 +53,22 @@ const Head = ({ title, description }) => {
       <meta name="description" content={description ?? defaultDescription} />
 
       <meta property="og:type" content="website" />
-      <meta property="og:url" content={siteURL} />
+      <meta property="og:url" content={siteUrl} />
       <meta property="og:title" content={title ?? defaultTitle} />
       <meta
         property="og:description"
         content={description ?? defaultDescription}
       />
-      <meta property="og:image" content={`${siteURL}${image.slice(1)}`} />
+      <meta property="og:image" content={`${siteUrl}${metaImage}`} />
 
       <meta property="twitter:card" content="summary_large_image" />
-      <meta property="twitter:url" content={siteURL} />
+      <meta property="twitter:url" content={siteUrl} />
       <meta property="twitter:title" content={title ?? defaultTitle} />
       <meta
         property="twitter:description"
         content={description ?? defaultDescription}
       />
-      <meta property="twitter:image" content={`${siteURL}${image.slice(1)}`} />
+      <meta property="twitter:image" content={`${siteUrl}${metaImage}`} />
     </Helmet>
   );
 };

--- a/src/components/ItemsPage.js
+++ b/src/components/ItemsPage.js
@@ -22,6 +22,7 @@ const ItemsPage = ({
   location,
   title,
   description,
+  image,
   itemsPath,
   variant,
   Character,
@@ -79,7 +80,7 @@ const ItemsPage = ({
   };
 
   return (
-    <Layout title={title} description={description}>
+    <Layout title={title} description={description} image={image}>
       <Spacer />
       <header className={css.header}>
         <Heading1 className={css.heading} variant={variant}>

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -10,10 +10,10 @@ import '../styles/fonts.css';
 
 import * as css from './Layout.module.css';
 
-const Layout = ({ children, title }) => {
+const Layout = ({ children, title, description, image }) => {
   return (
     <div className={css.container}>
-      <Head title={title} />
+      <Head title={title} description={description} image={image} />
       <div className={css.content}>
         <TopBar />
         {children}

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -16,7 +16,7 @@ import * as css from '../styles/pages/404.module.css';
 const NotFoundPage = ({ data }) => {
   const { title, description, links } = data.pageData.nodes[0];
   return (
-    <Layout title="Page not found!" description={description}>
+    <Layout title={title} description={description}>
       <Spacer />
 
       <header className={css.header}>

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -96,7 +96,7 @@ const AboutPage = ({ data }) => {
   const secondaryCover = content.covers[1].file.childImageSharp.gatsbyImageData;
 
   return (
-    <Layout title="About" description={secondaryDescription}>
+    <Layout title="About" description={secondaryDescription} image={mainCover}>
       <Spacer />
 
       <header className={css.row}>

--- a/src/pages/guides.js
+++ b/src/pages/guides.js
@@ -23,7 +23,10 @@ const GuidesPage = ({ data }) => {
       ? data.guidesPlaceholderImage.nodes[0].childImageSharp.gatsbyImageData
       : null;
   return (
-    <Layout title={pageData.title} description={pageData.description}>
+    <Layout
+      title={pageData.title}
+      description={pageData.description}
+      image={guidesPlaceholderImage}>
       <Spacer />
       <header className={css.header}>
         <Heading1 className={css.heading} variant="purple">

--- a/src/templates/challenge.js
+++ b/src/templates/challenge.js
@@ -29,7 +29,10 @@ const Challenge = ({ data }) => {
       ? contributionPlaceholderImage.nodes[0].childImageSharp.gatsbyImageData
       : challengesPlaceholder;
   return (
-    <Layout title={challenge.title} description={challenge.description}>
+    <Layout
+      title={challenge.title}
+      description={challenge.description}
+      image={contributionPlaceholderImage}>
       <Breadcrumbs
         className={css.breadcrumbs}
         breadcrumbs={[

--- a/src/templates/challenge.js
+++ b/src/templates/challenge.js
@@ -32,7 +32,7 @@ const Challenge = ({ data }) => {
     <Layout
       title={challenge.title}
       description={challenge.description}
-      image={contributionPlaceholderImage}>
+      image={contributionsPlaceholder}>
       <Breadcrumbs
         className={css.breadcrumbs}
         breadcrumbs={[

--- a/src/templates/challenges.js
+++ b/src/templates/challenges.js
@@ -30,6 +30,7 @@ const ChallengesPage = ({ data, pageContext, location }) => {
     <ItemsPage
       title={pageData.title}
       description={pageData.description}
+      image={challengePlaceholderImage}
       location={location}
       itemsPath="challenges"
       variant="cyan"

--- a/src/templates/challenges.js
+++ b/src/templates/challenges.js
@@ -30,7 +30,7 @@ const ChallengesPage = ({ data, pageContext, location }) => {
     <ItemsPage
       title={pageData.title}
       description={pageData.description}
-      image={challengePlaceholderImage}
+      image={challengesPlaceholder}
       location={location}
       itemsPath="challenges"
       variant="cyan"

--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -166,7 +166,10 @@ const Guide = ({ data }) => {
   const localImages = useLocalImages(images.nodes);
 
   return (
-    <Layout title={mdx.frontmatter.title}>
+    <Layout
+      title={mdx.frontmatter.title}
+      description={mdx.frontmatter.description}
+      image={localImages['placeholder.png']}>
       <Breadcrumbs
         className={css.breadcrumbs}
         breadcrumbs={[
@@ -219,6 +222,7 @@ export const query = graphql`
       tableOfContents
       frontmatter {
         title
+        description
       }
     }
     images: allCoverImage(

--- a/src/templates/track-video.js
+++ b/src/templates/track-video.js
@@ -41,7 +41,8 @@ const Track = ({ pageContext, data }) => {
   return (
     <Layout
       title={isTrackPage ? track.title : video.title}
-      description={isTrackPage ? track.description : video.description}>
+      description={isTrackPage ? track.description : video.description}
+      image={contributionsPlaceholder}>
       <Breadcrumbs
         className={css.breadcrumbs}
         breadcrumbs={[

--- a/src/templates/track-video.js
+++ b/src/templates/track-video.js
@@ -42,7 +42,11 @@ const Track = ({ pageContext, data }) => {
     <Layout
       title={isTrackPage ? track.title : video.title}
       description={isTrackPage ? track.description : video.description}
-      image={contributionsPlaceholder}>
+      image={
+        isTrackPage && track.cover
+          ? track.cover.file.childImageSharp.gatsbyImageData
+          : contributionsPlaceholder
+      }>
       <Breadcrumbs
         className={css.breadcrumbs}
         breadcrumbs={[
@@ -165,6 +169,13 @@ export const query = graphql`
           slug
           languages
           topics
+        }
+      }
+      cover {
+        file {
+          childImageSharp {
+            gatsbyImageData
+          }
         }
       }
     }

--- a/src/templates/tracks.js
+++ b/src/templates/tracks.js
@@ -26,6 +26,7 @@ const TracksPage = ({ data, pageContext, location }) => {
     <ItemsPage
       title={pageData.title}
       description={pageData.description}
+      image={placeholderMainTrackImage}
       location={location}
       itemsPath="tracks"
       variant="red"


### PR DESCRIPTION
This completes the metadata settings initially set for the site, and also adds images to the setup as proposed in #170.

The approach is taking both text and image content already worked on for every site and using it as metadata for each page.

For example, for titles and descriptions, which most pages have, this are also injected as metadata for the corresponding page. So tracks titles and descriptions get injected in the first video page of each track, and each individual video page also has their own title and description metadata.

Images would work the same way. I'll show here how each preview looks, and indicate where is the image taken from. Some images probably will need to be replaced, since some are still placeholders from a while ago.

Also a little note: Because the meta tags only accept full URLs for image sources, metadata images point to images that are available in `thecodingtrain.com`, instead of the current preview URL. Because there's consistency across builds, it should link to the same images if a new build has the same images as the main build. But if new images are added in a separate branch-preview, it probably won't point to the right image unless the branch is merged into main.

Path: `/`
Image: `content/tracks/main-tracks/placeholder.jpg` (This is also the default value for all pages. If there's no image available, this will show).

<img width="434" alt="Screen Shot 2022-06-09 at 15 38 11" src="https://user-images.githubusercontent.com/13511560/172930420-5d906b84-a6a7-4e9c-859b-096d7672b673.png">

Path: `/tracks`
Image: `content/tracks/main-tracks/placeholder.jpg`
<img width="414" alt="Screen Shot 2022-06-09 at 15 46 47" src="https://user-images.githubusercontent.com/13511560/172931791-2d474cec-cf18-40d6-b849-062c03a327c8.png">

Path: `/challenges`
Image: `content/videos/challenges/placeholder.jpg`

<img width="437" alt="Screen Shot 2022-06-09 at 15 47 15" src="https://user-images.githubusercontent.com/13511560/172931878-21db414a-2704-4928-9070-e3fe70324f1b.png">

Path: `/guides`
Image: `content/pages/guides/placeholder.png`

<img width="414" alt="Screen Shot 2022-06-09 at 15 48 29" src="https://user-images.githubusercontent.com/13511560/172932081-f695ee27-2463-4db7-b480-86b1ac1bdb26.png">

Path: `/about`
Image: First image linked in the key `"covers"` in `content/pages/about/index.json`

<img width="436" alt="Screen Shot 2022-06-09 at 15 49 24" src="https://user-images.githubusercontent.com/13511560/172932224-d6631d1c-935c-4a8a-9acc-2ca21fc33dcc.png">

Path: `/challenges/#-specific-challenge`
Image: `content/videos/challenges/#-specific-challenge/index.jpg`. If that one doesn't exists, it fallback to `content/videos/challenges/placeholder.jpg`.

<img width="414" alt="Screen Shot 2022-06-09 at 15 52 07" src="https://user-images.githubusercontent.com/13511560/172932668-39662dc9-fe61-426a-8b22-1e614264e35c.png">


Path: `/tracks/specific-track`
Image: `content/tracks/[main|side]-tracks/specific-track/index.jpg`. If that one doesn't exists, it fallback to the videos image.

<img width="414" alt="Screen Shot 2022-06-09 at 15 55 04" src="https://user-images.githubusercontent.com/13511560/172933108-19a3baf6-1f5e-4665-99f1-238b51dd3fd2.png">

Path: `/tracks/specific-track/specific-video`
Image: `content/videos/specific-path/index.jpg`. If that one doesn't exists, it fallback to `content/videos/placeholder.png`.

<img width="414" alt="Screen Shot 2022-06-09 at 15 58 22" src="https://user-images.githubusercontent.com/13511560/172933629-26ccd0b2-1efc-4dee-a5f3-880352a17be8.png">

Path: `/guides/specific-guide`
Image: `content/pages/guides/placeholder.png`

<img width="414" alt="Screen Shot 2022-06-09 at 15 59 59" src="https://user-images.githubusercontent.com/13511560/172933884-85b12e70-d743-43fb-ba79-441e3e1ec185.png">

