### PR TITLE
Fix link title 

### DIFF
--- a/content/videos/challenges/19-superellipse/index.json
+++ b/content/videos/challenges/19-superellipse/index.json
@@ -31,7 +31,7 @@
           "description": "Wikipedia Entry on Superellipses"
         },
         {
-          "title": "Space Colonization Algorithm",
+          "title": "Supershapes",
           "url": "http://paulbourke.net/geometry/supershape/",
           "description": "Supershapes (Superformula) by Paul Bourke"
         }


### PR DESCRIPTION
Fixed link name for the Supershapes website

Apparently, even in the [old website](https://codingtrain.github.io/website-archive/CodingChallenges/019-superellipse.html) the supershapes link was named "space colonization algorithm"