### PR TITLE
Add tooltip to Contribution header for long names

### DIFF
--- a/src/components/PassengerShowcasePanel.js
+++ b/src/components/PassengerShowcasePanel.js
@@ -66,7 +66,7 @@ const Contribution = ({
   return (
     <article className={css.contrib}>
       <a className={css.title} href={url} target="_blank" rel="noreferrer">
-        <Header>{title}</Header>
+        <Header title={title.length > 30 ? title : null}>{title}</Header>
       </a>
       <a
         className={css.pictureContainer}


### PR DESCRIPTION
In many Passenger Showcase contributions, the names are long and are cut off.
![image](https://user-images.githubusercontent.com/59444569/178156122-c69923bf-16a5-48ea-a55c-7a508a36b865.png)

This PR adds a tooltip which shows the full name of the contribution on hovering on its header. This is only applied to names longer than 30 characters long.

![image](https://user-images.githubusercontent.com/59444569/178156179-fa37be2a-1d20-4a01-b613-55e5f5e1ee1d.png)
(Here, I am hovering on the contribution header. The mouse is not visible in screenshots.)