### PR TITLE
feat: adds ability to sort tracks in track page

### DIFF
--- a/content-testing/content-structure.js
+++ b/content-testing/content-structure.js
@@ -1,6 +1,7 @@
 const {
   video: videoFormat,
   track: trackFormat,
+  trackOrder: trackOrderFormat,
   contribution: contributionFormat,
   faqPage: faqPageFormat,
   faq: faqFormat
@@ -9,6 +10,7 @@ const {
 const {
   video: videoSlugReferences,
   track: trackSlugReference,
+  trackOrder: trackOrderSlugReference,
   faqsOrder: faqsOrderSlugReference
 } = require('./slug-references.js');
 
@@ -231,7 +233,13 @@ const contentStructure = {
           isRequired: true
         }
       },
-      files: {},
+      files: {
+        'index.json': {
+          isRequired: false,
+          jsonFormat: trackOrderFormat,
+          slugReferences: trackOrderSlugReference
+        }
+      },
       isFileSensitive: true,
       isFolderSensitive: true,
       isRequired: true

--- a/content-testing/file-formats.js
+++ b/content-testing/file-formats.js
@@ -89,6 +89,20 @@ const video = {
   }
 };
 
+const trackOrder = {
+  name: 'trackOrder',
+  init: {
+    type: 'object',
+    properties: {
+      trackOrder: {
+        isRequired: true,
+        type: 'array',
+        content: { type: 'string' }
+      }
+    }
+  }
+};
+
 const track = {
   name: 'track',
   init: {
@@ -241,6 +255,7 @@ const collaborators = {
 module.exports = {
   video,
   track,
+  trackOrder,
   contribution,
   faq,
   faqPage,

--- a/content-testing/slug-references.js
+++ b/content-testing/slug-references.js
@@ -4,6 +4,12 @@ const video = {
   relativePath: './content/videos/challenges'
 };
 
+const trackOrder = {
+  name: 'trackOrder',
+  getSlugs: (file) => [...file.trackOrder],
+  relativePath: './content/tracks'
+};
+
 const track = {
   name: 'track',
   getSlugs: (track) => {
@@ -32,5 +38,6 @@ const faqsOrder = {
 module.exports = {
   video,
   track,
+  trackOrder,
   faqsOrder
 };

--- a/content/tracks/index.json
+++ b/content/tracks/index.json
@@ -1,0 +1,13 @@
+{
+  "trackOrder": [
+    "main-tracks/code-programming-with-p5-js",
+    "main-tracks/data-and-apis-in-javascript",
+    "main-tracks/git-github-for-poets",
+    "main-tracks/ml5js-beginners-guide",
+    "main-tracks/the-nature-of-code-2",
+    "side-tracks/2018-workflow",
+    "side-tracks/algorithmic-botany",
+    "side-tracks/coding-in-the-cabana",
+    "side-tracks/p5-tips-and-tricks"
+  ]
+}

--- a/node-scripts/node-generation.js
+++ b/node-scripts/node-generation.js
@@ -34,8 +34,8 @@ const parseTimestamp = (timeString) => {
 
 /**
  * Add computed seconds to an array of Timestamp objets (creates a new array).
- * 
- * @param {{ time: string, title: string }[]} timestamps 
+ *
+ * @param {{ time: string, title: string }[]} timestamps
  * @returns the timestamps with computed seconds
  */
 const timestampsWithSeconds = (timestamps) => {
@@ -209,6 +209,26 @@ const computeTrackTags = (trackDirectory, type) => {
   return [languages, topics].map((s) => [...s]);
 };
 
+const trackOrderPath = './content/tracks/index.json';
+
+const getTrackOrder = (trackSlug, trackType) => {
+  if (!fs.existsSync(trackOrderPath)) return 99999;
+
+  try {
+    const trackOrderJSON = JSON.parse(fs.readFileSync(trackOrderPath));
+
+    for (let index = 0; index < trackOrderJSON.trackOrder.length; index++) {
+      if (trackOrderJSON.trackOrder[index] === `${trackType}/${trackSlug}`)
+        return index;
+    }
+  } catch (error) {
+    console.log(`Error loading track order file: ${trackOrderPath}`);
+    console.error(error);
+  }
+
+  return 99999;
+};
+
 /**
  * Creates Track node from JSON file node
  * @param {function} createNode - Gatsby's createNode function
@@ -261,12 +281,16 @@ exports.createTrackRelatedNode = (
     parent.relativeDirectory,
     trackType
   );
+
+  const order = getTrackOrder(slug, trackType);
+
   const newNode = Object.assign({}, data, {
     id,
     parent: node.id,
     type,
     slug,
     numVideos,
+    order,
     cover: createNodeId(`cover-image/${trackType}/${slug}`),
     languages,
     languagesFlat: languages.join(),

--- a/node-scripts/schema.js
+++ b/node-scripts/schema.js
@@ -164,6 +164,7 @@ type Track implements Node {
   videos: [VideoInterface] @link
   cover: CoverImage @link
   numVideos: Int!
+  order: Int!
 }
 
 type Talk implements Node {

--- a/src/templates/tracks.js
+++ b/src/templates/tracks.js
@@ -68,7 +68,7 @@ const TracksPage = ({ data, pageContext, location }) => {
 };
 
 export const query = graphql`
-  query(
+  query (
     $skip: Int!
     $limit: Int!
     $topicRegex: String!
@@ -85,6 +85,7 @@ export const query = graphql`
         languagesFlat: { regex: $languageRegex }
         topicsFlat: { regex: $topicRegex }
       }
+      sort: { order: ASC, fields: order }
       skip: $skip
       limit: $limit
     ) {


### PR DESCRIPTION
As proposed in #417, this adds the loading of an JSON file that defined the order in which tracks are shown in the Track Page. The file should be located in `content/tracks/index.json`, and should be an object with a `"trackOrder"` property that is an array of slug strings for the tracks. If a track is not found in this array, it will get assigned a very high number.

This also adds the front-end graphql query, and tests for this new file.