### PR TITLE
Fixed typo

### DIFF
--- a/content/videos/challenges/173-snake-applesoft-basic/index.json
+++ b/content/videos/challenges/173-snake-applesoft-basic/index.json
@@ -79,7 +79,7 @@
           "icon": "🍎",
           "title": "Basic Programming Reference Manual",
           "url": "https://mirrors.apple2.org.za/Apple%20II%20Documentation%20Project/Software/Languages/Applesoft%20BASIC/Manuals/Applesoft%20II%20BASIC%20Programming%20Reference%20Manual.pdf",
-          "description": "PDF of originan Apple II manual and reference for AppleSoft BASIC."
+          "description": "PDF of original Apple II manual and reference for AppleSoft BASIC."
         },
         {
           "icon": "🪧",


### PR DESCRIPTION
Fixed typo in AppleSoft BASIC manual description ("originan" -> "original").