### PR TITLE
Add track cover image as share preview

### DIFF
--- a/src/templates/track-video.js
+++ b/src/templates/track-video.js
@@ -37,15 +37,19 @@ const Track = ({ pageContext, data }) => {
 
   const { trackPosition, isTrackPage } = pageContext;
 
+  const trackImage = track.cover
+    ? track.cover.file.childImageSharp.gatsbyImageData
+    : contributionsPlaceholder;
+
+  const videoImage = video.cover
+    ? video.cover.file.childImageSharp.gatsbyImageData
+    : trackImage;
+
   return (
     <Layout
       title={isTrackPage ? track.title : video.title}
       description={isTrackPage ? track.description : video.description}
-      image={
-        track.cover
-          ? track.cover.file.childImageSharp.gatsbyImageData
-          : contributionsPlaceholder
-      }>
+      image={isTrackPage ? trackImage : videoImage}>
       <Breadcrumbs
         className={css.breadcrumbs}
         breadcrumbs={[

--- a/src/templates/track-video.js
+++ b/src/templates/track-video.js
@@ -36,13 +36,13 @@ const Track = ({ pageContext, data }) => {
     challengePlaceholderImage.childImageSharp.gatsbyImageData;
 
   const { trackPosition, isTrackPage } = pageContext;
-
+  console.log(track);
   return (
     <Layout
       title={isTrackPage ? track.title : video.title}
       description={isTrackPage ? track.description : video.description}
       image={
-        isTrackPage && track.cover
+        track.cover
           ? track.cover.file.childImageSharp.gatsbyImageData
           : contributionsPlaceholder
       }>
@@ -141,7 +141,7 @@ const Track = ({ pageContext, data }) => {
 };
 
 export const query = graphql`
-  query(
+  query (
     $trackId: String
     $videoId: String
     $videoSlug: String

--- a/src/templates/track-video.js
+++ b/src/templates/track-video.js
@@ -36,7 +36,7 @@ const Track = ({ pageContext, data }) => {
     challengePlaceholderImage.childImageSharp.gatsbyImageData;
 
   const { trackPosition, isTrackPage } = pageContext;
-  console.log(track);
+
   return (
     <Layout
       title={isTrackPage ? track.title : video.title}


### PR DESCRIPTION
This PR resolves #514.
- Use track cover image for share preview
- Prioritizes `index.png` for video over track thumbnail
