### PR TITLE
yt-desc: Use website URL as input

### DIFF
--- a/node-scripts/yt-description.js
+++ b/node-scripts/yt-description.js
@@ -90,7 +90,7 @@ function getVideoData(file) {
     );
   }
 
-  if (parsed.parts && !parsed.videoId) {
+  if (parsed.parts && parsed.parts.length > 0) {
     // Multipart Coding Challenge
     // https://github.com/CodingTrain/thecodingtrain.com/issues/420#issuecomment-1218529904
 
@@ -311,7 +311,7 @@ Music from Epidemic Sound
 
 This description was auto-generated. If you see a problem, please open an issue: https://github.com/CodingTrain/thecodingtrain.com/issues/new`;
 
-  let filename = /\/((?:.(?!\/))+)$/.exec(pageURL)[1];
+  let filename = data.videoId;
   fs.writeFileSync(`_descriptions/${filename}.txt`, description);
 
   return description;
@@ -349,12 +349,14 @@ const allTracks = [...mainTracks, ...sideTracks];
       getVideoData(file);
     }
 
-    const videoInfo = videos.find((data) => data.filePath === fileName);
+    const specifiedVideos = videos.filter((data) => data.filePath === fileName);
 
-    const description = writeDescription(videoInfo);
-    console.log('=====================================================');
-    console.log(description);
-    console.log('=====================================================');
+    for (const video of specifiedVideos) {
+      const description = writeDescription(video);
+      console.log('=====================================================');
+      console.log(description);
+      console.log('=====================================================');
+    }
   } else {
     for (const file of files) {
       getVideoData(file);

--- a/node-scripts/yt-description.js
+++ b/node-scripts/yt-description.js
@@ -311,7 +311,8 @@ Music from Epidemic Sound
 
 This description was auto-generated. If you see a problem, please open an issue: https://github.com/CodingTrain/thecodingtrain.com/issues/new`;
 
-  let filename = data.videoId || /\/((?:.(?!\/))+)$/.exec(pageURL)[1];
+  const videoSlug = /\/((?:.(?!\/))+)$/.exec(pageURL)[1];
+  let filename = videoSlug + '_' + data.videoId;
   fs.writeFileSync(`_descriptions/${filename}.txt`, description);
 
   return description;

--- a/node-scripts/yt-description.js
+++ b/node-scripts/yt-description.js
@@ -62,9 +62,8 @@ function parseTrack(track) {
 }
 
 /**
- * Gets
+ * Parses index.json and pushes to videos array
  * @param {string} file File to parse
- * @returns
  */
 function getVideoData(file) {
   const content = fs.readFileSync(`./${file}`, 'utf-8');
@@ -85,17 +84,41 @@ function getVideoData(file) {
     }
   }
 
-  if (!url || url.length == 0)
+  if (!url || url.length == 0) {
     throw new Error(
       'Something went wrong in parsing this file: ' + filePath.join('/')
     );
-  const videoData = {
-    pageURL: url.join('/'),
-    data: parsed,
-    filePath: file
-  };
-  videos.push(videoData);
-  return videoData;
+  }
+
+  if (parsed.parts && !parsed.videoId) {
+    // Multipart Coding Challenge
+    // https://github.com/CodingTrain/thecodingtrain.com/issues/420#issuecomment-1218529904
+
+    for (const part of parsed.parts) {
+      // copy all info from base object
+      const partInfo = JSON.parse(JSON.stringify(parsed));
+      delete partInfo.parts;
+
+      // copy videoId, title, timestamps from parts
+      partInfo.videoId = part.videoId;
+      partInfo.title = parsed.title + ' - ' + part.title;
+      partInfo.timestamps = part.timestamps;
+
+      const videoData = {
+        pageURL: url.join('/'),
+        data: partInfo,
+        filePath: file
+      };
+      videos.push(videoData);
+    }
+  } else {
+    const videoData = {
+      pageURL: url.join('/'),
+      data: parsed,
+      filePath: file
+    };
+    videos.push(videoData);
+  }
 }
 
 /**

--- a/node-scripts/yt-description.js
+++ b/node-scripts/yt-description.js
@@ -184,7 +184,7 @@ function writeDescription(video) {
 
   // Description
   description += `${data.description.trim()}`;
-  description += ` https://thecodingtrain.com/${pageURL}`;
+  description += ` Code: https://thecodingtrain.com/${pageURL}`;
 
   description += '\n';
 

--- a/node-scripts/yt-description.js
+++ b/node-scripts/yt-description.js
@@ -179,7 +179,7 @@ function writeDescription(video) {
 
   // Code Examples:
 
-  // Github Repo Link
+  // Github Standalone Repo Link
   const repoLink = data.codeExamples
     ?.map((ex) => Object.values(ex.urls))
     .flat()

--- a/node-scripts/yt-description.js
+++ b/node-scripts/yt-description.js
@@ -311,7 +311,7 @@ Music from Epidemic Sound
 
 This description was auto-generated. If you see a problem, please open an issue: https://github.com/CodingTrain/thecodingtrain.com/issues/new`;
 
-  let filename = data.videoId;
+  let filename = data.videoId || /\/((?:.(?!\/))+)$/.exec(pageURL)[1];
   fs.writeFileSync(`_descriptions/${filename}.txt`, description);
 
   return description;

--- a/node-scripts/yt-description.js
+++ b/node-scripts/yt-description.js
@@ -1,3 +1,14 @@
+// Coding Train YouTube Description Generator
+
+// Usage:
+// All Videos: npm run yt-desc
+// Specific Video: npm run yt-desc <coding-train-website-url>
+
+// example:
+// npm run yt-desc https://thecodingtrain.com/challenges/171-wave-function-collapse
+
+// Output files are saved to `./_descriptions` directory
+
 const fs = require('fs');
 const path = require('path');
 
@@ -339,18 +350,21 @@ const allTracks = [...mainTracks, ...sideTracks];
   primeDirectory('./_descriptions');
 
   if (video) {
-    const fileName = path.join(
-      'content',
-      'videos',
-      ...video.split('/'),
-      'index.json'
-    );
+    let pathName;
+    try {
+      pathName = new URL(video).pathname;
+    } catch (e) {
+      console.error('Unable to parse video URL.');
+      process.exit(1);
+    }
 
     for (const file of files) {
       getVideoData(file);
     }
 
-    const specifiedVideos = videos.filter((data) => data.filePath === fileName);
+    const specifiedVideos = videos.filter(
+      (data) => '/' + data.pageURL === pathName
+    );
 
     for (const video of specifiedVideos) {
       const description = writeDescription(video);


### PR DESCRIPTION
Based on comments by @shiffman on https://github.com/CodingTrain/thecodingtrain.com/issues/205#issuecomment-1236461778

Merge after #537

- Changes script CLI to use the website URL instead of file path.
- Add `Code:` before website url in description

❗Note: For videos in multiple tracks, only one URL will work (usually, the directory in which its metadata is present).

```
Coding Train YouTube Description Generator

Usage:
All Videos: npm run yt-desc
Specific Video: npm run yt-desc <coding-train-website-url>

example:
npm run yt-desc https://thecodingtrain.com/challenges/171-wave-function-collapse

Output files are saved to `./_descriptions` directory
```
