### PR TITLE
Code! fixing typos and adding links

### DIFF
--- a/content/videos/code/3-conditionals/4-boolean/index.json
+++ b/content/videos/code/3-conditionals/4-boolean/index.json
@@ -10,8 +10,8 @@
   "timestamps": [
     {"time": "0:00", "title": "Introduction" },
     {"time": "0:48", "title": "Boolean Variables -- TRUE or FALSE" },
-    {"time": "3:00", "title": "Distiction Between Mouse is Clicked and Mouse is Pressed" },
-    {"time": "8:00", "title": "Assiging States to the Program" },
+    {"time": "3:00", "title": "Distinction Between Mouse is Clicked and Mouse is Pressed" },
+    {"time": "8:00", "title": "Assigning States to the Program" },
     {"time": "11:50", "title": "mousePressed()" },
     {"time": "13:35", "title": "Toggling the State" },
     {"time": "14:36", "title": "The NOT operator" }

--- a/content/videos/code/6-objects/2-classes/index.json
+++ b/content/videos/code/6-objects/2-classes/index.json
@@ -12,7 +12,7 @@
     {"time": "3:09", "title": "Encapsulation" },
     {"time": "3:37", "title": "Using Classes as a Template for Objects" },
     {"time": "8:40", "title": "The constructor() Function is the Object's Setup" },
-    {"time": "10:10", "title": "Using \u201cths.\u201d to Declare Class Variables" },
+    {"time": "10:10", "title": "Using \u201cthis.\u201d to Declare Class Variables" },
     {"time": "12:26", "title": "Code Example" },
     {"time": "14:50", "title": "Adding Functionality to a Class" }
   ],

--- a/content/videos/code/6-objects/3-constructor/index.json
+++ b/content/videos/code/6-objects/3-constructor/index.json
@@ -21,5 +21,23 @@
       }
     }
   ],
-  "groupLinks": []
+  "groupLinks": [
+    {
+      "title": "Videos",
+      "links": [
+        {
+          "icon": "🚂",
+          "title": "ES6 playlist",
+          "url": "/tracks/topics-in-native-javascript",
+          "description": "Video tutorials covering various features of modern JavaScript."
+        },
+        {
+          "icon": "🚂",
+          "title": "Function Parameters and Arguments",
+          "url": "/tracks/code-programming-with-p5-js/code/5-functions/2-arguments",
+          "description": "This video looks at re-usability and functions."
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Fixing typos in the timestamps for two videos and adding 2 links that were in the description in 6.3.