### PR TITLE
Adding "relatedChallenges" to Random Walk related challenges

### DIFF
--- a/content/videos/challenges/162-self-avoiding-walk/index.json
+++ b/content/videos/challenges/162-self-avoiding-walk/index.json
@@ -7,6 +7,10 @@
   "languages": ["p5.js", "JavaScript"],
   "topics": ["self avoiding walk", "backtracking"],
   "canContribute": true,
+  "relatedChallenges": [
+    "52-random-walker",
+    "53-random-walker-with-vectors-and-levy-flight"
+  ],
   "timestamps": [
     {
       "time": "0:00:00",

--- a/content/videos/challenges/162-self-avoiding-walk/index.json
+++ b/content/videos/challenges/162-self-avoiding-walk/index.json
@@ -7,10 +7,7 @@
   "languages": ["p5.js", "JavaScript"],
   "topics": ["self avoiding walk", "backtracking"],
   "canContribute": true,
-  "relatedChallenges": [
-    "52-random-walker",
-    "10-dfs-maze-generator"
-  ],
+  "relatedChallenges": ["52-random-walker", "10-dfs-maze-generator"],
   "timestamps": [
     {
       "time": "0:00:00",

--- a/content/videos/challenges/162-self-avoiding-walk/index.json
+++ b/content/videos/challenges/162-self-avoiding-walk/index.json
@@ -9,7 +9,7 @@
   "canContribute": true,
   "relatedChallenges": [
     "52-random-walker",
-    "53-random-walker-with-vectors-and-levy-flight"
+    "10-dfs-maze-generator"
   ],
   "timestamps": [
     {
@@ -168,7 +168,7 @@
         },
         {
           "icon": "🎥",
-          "title": "Recursion - Coding Train 77",
+          "title": "Recursion - Coding Challenge 77",
           "url": "https://www.youtube.com/watch?v=jPsZwrV9ld0",
           "description": "The concept of recursion is used to create fractal patterns in p5.js."
         },

--- a/content/videos/challenges/162-self-avoiding-walk/index.json
+++ b/content/videos/challenges/162-self-avoiding-walk/index.json
@@ -145,13 +145,13 @@
         {
           "icon": "🎥",
           "title": "Random Walker - Coding Challenge 52",
-          "url": "https://www.youtube.com/watch?v=l__fEY1xanY",
+          "url": "/challenges/52-random-walker",
           "description": "A random walker is implemented in p5.js"
         },
         {
           "icon": "🎥",
           "title": "Minesweeper - Coding Challenge 71",
-          "url": "https://www.youtube.com/watch?v=LFU5ZlrR21E",
+          "url": "/challenges/71-minesweeper",
           "description": "The classic game of minesweeper is implemented in p5.js."
         },
         {
@@ -163,19 +163,19 @@
         {
           "icon": "🎥",
           "title": "Maze Generator - Coding Challenge 10",
-          "url": "https://www.youtube.com/watch?v=HyK_Q5rrcr4",
+          "url": "/challenges/10-dfs-maze-generator",
           "description": "A maze generator is implemented in p5.js"
         },
         {
           "icon": "🎥",
           "title": "Recursion - Coding Challenge 77",
-          "url": "https://www.youtube.com/watch?v=jPsZwrV9ld0",
+          "url": "/challenges/77-recursion",
           "description": "The concept of recursion is used to create fractal patterns in p5.js."
         },
         {
           "icon": "🎥",
           "title": "A* Pathfinding Algorithm - Coding Challenge 51",
-          "url": "https://www.youtube.com/watch?v=aKYlikFAV4k",
+          "url": "/challenges/51-a-pathfinding-algorithm",
           "description": "An implementation of the A* pathfinding algorithm to find the optimal path between two points in a 2D grid"
         },
         {

--- a/content/videos/challenges/52-random-walker/index.json
+++ b/content/videos/challenges/52-random-walker/index.json
@@ -78,7 +78,7 @@
         {
           "icon": "🎥",
           "title": "Random Walker with Vectors and Lévy Flight",
-          "url": "https://www.youtube.com/watch?v=bqF9w9TTfeo",
+          "url": "/challenges/53-random-walker-with-vectors-and-levy-flight",
           "description": "Random walker using vectors to vary the distance of each step, and implementing Lévy Flight."
         }
       ]

--- a/content/videos/challenges/52-random-walker/index.json
+++ b/content/videos/challenges/52-random-walker/index.json
@@ -7,6 +7,10 @@
   "languages": ["p5.js", "JavaScript", "Processing", "Java"],
   "topics": ["random", "floor", "random walker"],
   "canContribute": true,
+  "relatedChallenges": [
+    "53-random-walker-with-vectors-and-levy-flight",
+    "162-self-avoiding-walk"
+  ],
   "timestamps": [
     {
       "time": "0:00",

--- a/content/videos/challenges/53-random-walker-with-vectors-and-levy-flight/index.json
+++ b/content/videos/challenges/53-random-walker-with-vectors-and-levy-flight/index.json
@@ -13,10 +13,7 @@
     "probability"
   ],
   "canContribute": true,
-  "relatedChallenges": [
-    "52-random-walker",
-    "162-self-avoiding-walk"
-  ],
+  "relatedChallenges": ["52-random-walker", "162-self-avoiding-walk"],
   "timestamps": [
     {
       "time": "0:00",

--- a/content/videos/challenges/53-random-walker-with-vectors-and-levy-flight/index.json
+++ b/content/videos/challenges/53-random-walker-with-vectors-and-levy-flight/index.json
@@ -87,7 +87,7 @@
         {
           "icon": "📽",
           "title": "Coding Challenge #52: Random Walker",
-          "url": "https://www.youtube.com/watch?v=l__fEY1xanY",
+          "url": "/challenges/52-random-walker",
           "description": "In this Coding Challenge, I implement a Random Walker using the p5.js library."
         }
       ]

--- a/content/videos/challenges/53-random-walker-with-vectors-and-levy-flight/index.json
+++ b/content/videos/challenges/53-random-walker-with-vectors-and-levy-flight/index.json
@@ -13,7 +13,10 @@
     "probability"
   ],
   "canContribute": true,
-  "relatedChallenges": [],
+  "relatedChallenges": [
+    "52-random-walker",
+    "162-self-avoiding-walk"
+  ],
   "timestamps": [
     {
       "time": "0:00",


### PR DESCRIPTION
These are the links I suggest : 
| Challenge | Related Challenges |
|---|---|
| 52-random-walker |  53-random-walker-with-vectors-and-levy-flight, 162-self-avoiding-walk |
| 53-random-walker-with-vectors-and-levy-flight | 52-random-walker,  162-self-avoiding-walk |
| 162-self-avoiding-walk | 52-random-walker, 10-dfs-maze-generator |

I also replaced YouTube video links with links to the corresponding challenge pages on the website

Affected pages preview : 
- https://deploy-preview-568--codingtrain.netlify.app/challenges/52-random-walker
- https://deploy-preview-568--codingtrain.netlify.app/challenges/53-random-walker-with-vectors-and-levy-flight
- https://deploy-preview-568--codingtrain.netlify.app/challenges/162-self-avoiding-walk