### PR TITLE
Suggestion : Randomized related challenges view

### DIFF
--- a/content/videos/challenges/162-self-avoiding-walk/index.json
+++ b/content/videos/challenges/162-self-avoiding-walk/index.json
@@ -7,7 +7,12 @@
   "languages": ["p5.js", "JavaScript"],
   "topics": ["self avoiding walk", "backtracking"],
   "canContribute": true,
-  "relatedChallenges": ["52-random-walker", "10-dfs-maze-generator"],
+  "relatedChallenges": [
+    "52-random-walker",
+    "10-dfs-maze-generator",
+    "51-a-pathfinding-algorithm",
+    "71-minesweeper"
+  ],
   "timestamps": [
     {
       "time": "0:00:00",

--- a/src/components/ChallengesPanel.js
+++ b/src/components/ChallengesPanel.js
@@ -6,7 +6,7 @@ import Image from './Image';
 
 import * as css from './ChallengesPanel.module.css';
 import { getReadableDate } from '../hooks';
-import { shuffleCopy } from '../utils';
+import { shuffledCopy } from '../utils';
 
 const Card = ({
   className,
@@ -71,17 +71,16 @@ const Card = ({
     </article>
   );
 };
-const MemoizedCard = memo(Card);
 
 const ChallengesPanel = ({
   challenges,
   placeholderImage,
   headerType = 'h2',
-  randomize = false
+  shuffle = false
 }) => {
   const Header = headerType;
   const [shownChallenges, _] = useState(
-    (randomize ? shuffleCopy(challenges) : challenges).slice(0, 2)
+    (shuffle ? shuffledCopy(challenges) : challenges).slice(0, 2)
   );
   return (
     <section className={css.root}>
@@ -90,15 +89,15 @@ const ChallengesPanel = ({
         <p>Suggested by the video you're watching</p>
       </div>
       <div className={css.challenges}>
-        {shownChallenges.map((challenge, key) => (
-          <Fragment key={key}>
-            <MemoizedCard
+        {shownChallenges.map((challenge, index) => (
+          <Fragment key={challenge.videoId}>
+            <Card
               className={css.challenge}
               challenge={challenge}
               placeholderImage={placeholderImage}
               headerType={`h${parseFloat(headerType[1]) + 1}`}
             />
-            {key !== challenges.length - 1 && (
+            {index !== shownChallenges.length - 1 && (
               <div className={css.spacer}></div>
             )}
           </Fragment>
@@ -108,7 +107,4 @@ const ChallengesPanel = ({
   );
 };
 
-// The ChallengesPanel component itself cannot be memoized because otherwise,
-// the shuffled array will always appear the same on every page refresh when
-// building with SSR.
-export default ChallengesPanel;
+export default memo(ChallengesPanel);

--- a/src/components/ChallengesPanel.js
+++ b/src/components/ChallengesPanel.js
@@ -1,4 +1,4 @@
-import React, { Fragment, memo } from 'react';
+import React, { Fragment, memo, useState } from 'react';
 import { Link } from 'gatsby';
 import cn from 'classnames';
 
@@ -6,6 +6,7 @@ import Image from './Image';
 
 import * as css from './ChallengesPanel.module.css';
 import { getReadableDate } from '../hooks';
+import { shuffleCopy } from '../utils';
 
 const Card = ({
   className,
@@ -74,9 +75,13 @@ const Card = ({
 const ChallengesPanel = ({
   challenges,
   placeholderImage,
-  headerType = 'h2'
+  headerType = 'h2',
+  randomize = false
 }) => {
   const Header = headerType;
+  const [shownChallenges, _] = useState(
+    (randomize ? shuffleCopy(challenges) : challenges).slice(0, 2)
+  );
   return (
     <section className={css.root}>
       <div className={css.titleBox}>
@@ -84,7 +89,7 @@ const ChallengesPanel = ({
         <p>Suggested by the video you're watching</p>
       </div>
       <div className={css.challenges}>
-        {challenges.slice(0, 2).map((challenge, key) => (
+        {shownChallenges.map((challenge, key) => (
           <Fragment key={key}>
             <Card
               className={css.challenge}

--- a/src/components/ChallengesPanel.js
+++ b/src/components/ChallengesPanel.js
@@ -8,69 +8,66 @@ import * as css from './ChallengesPanel.module.css';
 import { getReadableDate } from '../hooks';
 import { shuffleCopy } from '../utils';
 
-const Card = ({
-  className,
-  challenge,
-  placeholderImage,
-  headerType = 'h3'
-}) => {
-  const { title, cover, description, date, slug, videoNumber } = challenge;
-  const Header = headerType;
-  return (
-    <article className={cn(css.challenge, className)}>
-      <div className={css.titleContainer}>
-        <div className={css.icon}>👁</div>
-        <Header className={css.title}>
-          {
-            <Link to={`/challenges/${slug}`}>
-              {videoNumber ? `#${videoNumber} — ` : ''} {title}
+const Card = memo(
+  ({ className, challenge, placeholderImage, headerType = 'h3' }) => {
+    const { title, cover, description, date, slug, videoNumber } = challenge;
+    const Header = headerType;
+    return (
+      <article className={cn(css.challenge, className)}>
+        <div className={css.titleContainer}>
+          <div className={css.icon}>👁</div>
+          <Header className={css.title}>
+            {
+              <Link to={`/challenges/${slug}`}>
+                {videoNumber ? `#${videoNumber} — ` : ''} {title}
+              </Link>
+            }
+          </Header>
+        </div>
+        <div className={css.thumb}>
+          <div className={css.left}>
+            <Link to={`/challenges/${slug}`} aria-label={title}>
+              {cover ? (
+                <Image
+                  image={cover.file.childImageSharp.gatsbyImageData}
+                  pictureClassName={css.picture}
+                  imgClassName={css.image}
+                  alt={`"${title}" challenge`}
+                />
+              ) : placeholderImage ? (
+                <Image
+                  image={placeholderImage}
+                  pictureClassName={css.picture}
+                  imgClassName={css.image}
+                  alt={`"${title}" challenge`}
+                />
+              ) : null}
             </Link>
-          }
-        </Header>
-      </div>
-      <div className={css.thumb}>
-        <div className={css.left}>
-          <Link to={`/challenges/${slug}`} aria-label={title}>
-            {cover ? (
-              <Image
-                image={cover.file.childImageSharp.gatsbyImageData}
-                pictureClassName={css.picture}
-                imgClassName={css.image}
-                alt={`"${title}" challenge`}
-              />
-            ) : placeholderImage ? (
-              <Image
-                image={placeholderImage}
-                pictureClassName={css.picture}
-                imgClassName={css.image}
-                alt={`"${title}" challenge`}
-              />
-            ) : null}
-          </Link>
-          <p className={css.date}>
-            <span>
-              {date ? (
-                <time dateTime={date}>{getReadableDate(date)}</time>
-              ) : null}
-            </span>
-          </p>
-        </div>
-        <div className={css.right}>
-          <div className={css.description}>
-            <p>{description}</p>
+            <p className={css.date}>
+              <span>
+                {date ? (
+                  <time dateTime={date}>{getReadableDate(date)}</time>
+                ) : null}
+              </span>
+            </p>
           </div>
-          <p className={css.date}>
-            <span>
-              {date ? (
-                <time dateTime={date}>{getReadableDate(date)}</time>
-              ) : null}
-            </span>
-          </p>
+          <div className={css.right}>
+            <div className={css.description}>
+              <p>{description}</p>
+            </div>
+            <p className={css.date}>
+              <span>
+                {date ? (
+                  <time dateTime={date}>{getReadableDate(date)}</time>
+                ) : null}
+              </span>
+            </p>
+          </div>
         </div>
-      </div>
-    </article>
-  );
-};
+      </article>
+    );
+  }
+);
 
 const ChallengesPanel = ({
   challenges,
@@ -107,4 +104,7 @@ const ChallengesPanel = ({
   );
 };
 
-export default memo(ChallengesPanel);
+// The ChallengesPanel component itself cannot be memoized because otherwise,
+// the shuffled array will always appear the same on every page refresh when
+// building with SSR.
+export default ChallengesPanel;

--- a/src/components/ChallengesPanel.js
+++ b/src/components/ChallengesPanel.js
@@ -6,7 +6,7 @@ import Image from './Image';
 
 import * as css from './ChallengesPanel.module.css';
 import { getReadableDate } from '../hooks';
-import { shuffleCopy, useSSR } from '../utils';
+import { shuffleCopy, useIsFirstRender } from '../utils';
 
 const Card = ({
   className,
@@ -80,14 +80,12 @@ const ChallengesPanel = ({
   headerType = 'h2'
 }) => {
   const Header = headerType;
-  const { isServer } = useSSR();
-  const [suggestions, setSuggestions] = useState(() =>
-    // Empty placeholders on server side render
-    challenges.map(() => ({})).slice(0, 2)
-  );
+  const isFirstRender = useIsFirstRender();
+  // First render : as many empty placeholders as there are challenges
+  const [suggestions, setSuggestions] = useState(challenges.map(() => ({})));
   useEffect(() => {
-    // Shuffled challenges on client side hydration
-    setSuggestions(shuffleCopy(challenges).slice(0, 2));
+    // Next renders : shuffled challenges on client side hydration
+    setSuggestions(shuffleCopy(challenges));
   }, [challenges]);
   return (
     <section className={css.root}>
@@ -96,12 +94,12 @@ const ChallengesPanel = ({
         <p>Suggested by the video you're watching</p>
       </div>
       <div className={css.challenges}>
-        {suggestions.map((challenge, index) => (
+        {suggestions.slice(0, 2).map((challenge, index) => (
           <Fragment key={challenge.videoNumber}>
             <Card
               className={css.challenge}
               challenge={challenge}
-              placeholderImage={isServer ? null : placeholderImage}
+              placeholderImage={isFirstRender ? null : placeholderImage}
               headerType={`h${parseFloat(headerType[1]) + 1}`}
             />
             {(suggestions.length === 1 || index !== suggestions.length - 1) && (

--- a/src/components/ChallengesPanel.js
+++ b/src/components/ChallengesPanel.js
@@ -1,4 +1,4 @@
-import React, { Fragment, memo, useState } from 'react';
+import React, { Fragment, memo, useEffect, useState } from 'react';
 import { Link } from 'gatsby';
 import cn from 'classnames';
 
@@ -6,7 +6,7 @@ import Image from './Image';
 
 import * as css from './ChallengesPanel.module.css';
 import { getReadableDate } from '../hooks';
-import { shuffledCopy } from '../utils';
+import { shuffledCopy, useIsClient } from '../utils';
 
 const Card = ({
   className,
@@ -79,17 +79,25 @@ const ChallengesPanel = ({
   shuffle = false
 }) => {
   const Header = headerType;
-  const [shownChallenges, _] = useState(
-    (shuffle ? shuffledCopy(challenges) : challenges).slice(0, 2)
+  const { key } = useIsClient();
+  const [suggestions, setSuggestions] = useState(
+    // This initial value is used on server side rendering
+    shuffledCopy(challenges, shuffle).slice(0, 2)
   );
+  useEffect(() => {
+    // This value is used on client side hydration, to shuffle the challenges
+    setSuggestions(shuffledCopy(challenges, shuffle).slice(0, 2));
+  }, [challenges, shuffle]);
   return (
     <section className={css.root}>
       <div className={css.titleBox}>
         <Header>Try a challenge!</Header>
         <p>Suggested by the video you're watching</p>
       </div>
-      <div className={css.challenges}>
-        {shownChallenges.map((challenge, index) => (
+      {/* This "key" attribute forces a fresh rerender on client side hydration,
+          which prevents a weird mix of static and dynamic content */}
+      <div className={css.challenges} key={key}>
+        {suggestions.map((challenge, index) => (
           <Fragment key={challenge.videoId}>
             <Card
               className={css.challenge}
@@ -97,7 +105,7 @@ const ChallengesPanel = ({
               placeholderImage={placeholderImage}
               headerType={`h${parseFloat(headerType[1]) + 1}`}
             />
-            {index !== shownChallenges.length - 1 && (
+            {index !== suggestions.length - 1 && (
               <div className={css.spacer}></div>
             )}
           </Fragment>

--- a/src/components/ChallengesPanel.js
+++ b/src/components/ChallengesPanel.js
@@ -6,7 +6,7 @@ import Image from './Image';
 
 import * as css from './ChallengesPanel.module.css';
 import { getReadableDate } from '../hooks';
-import { shuffledCopy, useIsClient } from '../utils';
+import { shuffledCopy, useIsSSR } from '../utils';
 
 const Card = ({
   className,
@@ -79,7 +79,7 @@ const ChallengesPanel = ({
   shuffle = false
 }) => {
   const Header = headerType;
-  const { key } = useIsClient();
+  const isSSR = useIsSSR();
   const [suggestions, setSuggestions] = useState(
     // This initial value is used on server side rendering
     shuffledCopy(challenges, shuffle).slice(0, 2)
@@ -96,7 +96,7 @@ const ChallengesPanel = ({
       </div>
       {/* This "key" attribute forces a fresh rerender on client side hydration,
           which prevents a weird mix of static and dynamic content */}
-      <div className={css.challenges} key={key}>
+      <div className={css.challenges} key={isSSR}>
         {suggestions.map((challenge, index) => (
           <Fragment key={challenge.videoId}>
             <Card

--- a/src/components/ChallengesPanel.js
+++ b/src/components/ChallengesPanel.js
@@ -8,66 +8,70 @@ import * as css from './ChallengesPanel.module.css';
 import { getReadableDate } from '../hooks';
 import { shuffleCopy } from '../utils';
 
-const Card = memo(
-  ({ className, challenge, placeholderImage, headerType = 'h3' }) => {
-    const { title, cover, description, date, slug, videoNumber } = challenge;
-    const Header = headerType;
-    return (
-      <article className={cn(css.challenge, className)}>
-        <div className={css.titleContainer}>
-          <div className={css.icon}>👁</div>
-          <Header className={css.title}>
-            {
-              <Link to={`/challenges/${slug}`}>
-                {videoNumber ? `#${videoNumber} — ` : ''} {title}
-              </Link>
-            }
-          </Header>
-        </div>
-        <div className={css.thumb}>
-          <div className={css.left}>
-            <Link to={`/challenges/${slug}`} aria-label={title}>
-              {cover ? (
-                <Image
-                  image={cover.file.childImageSharp.gatsbyImageData}
-                  pictureClassName={css.picture}
-                  imgClassName={css.image}
-                  alt={`"${title}" challenge`}
-                />
-              ) : placeholderImage ? (
-                <Image
-                  image={placeholderImage}
-                  pictureClassName={css.picture}
-                  imgClassName={css.image}
-                  alt={`"${title}" challenge`}
-                />
-              ) : null}
+const Card = ({
+  className,
+  challenge,
+  placeholderImage,
+  headerType = 'h3'
+}) => {
+  const { title, cover, description, date, slug, videoNumber } = challenge;
+  const Header = headerType;
+  return (
+    <article className={cn(css.challenge, className)}>
+      <div className={css.titleContainer}>
+        <div className={css.icon}>👁</div>
+        <Header className={css.title}>
+          {
+            <Link to={`/challenges/${slug}`}>
+              {videoNumber ? `#${videoNumber} — ` : ''} {title}
             </Link>
-            <p className={css.date}>
-              <span>
-                {date ? (
-                  <time dateTime={date}>{getReadableDate(date)}</time>
-                ) : null}
-              </span>
-            </p>
-          </div>
-          <div className={css.right}>
-            <div className={css.description}>
-              <p>{description}</p>
-            </div>
-            <p className={css.date}>
-              <span>
-                {date ? (
-                  <time dateTime={date}>{getReadableDate(date)}</time>
-                ) : null}
-              </span>
-            </p>
-          </div>
+          }
+        </Header>
+      </div>
+      <div className={css.thumb}>
+        <div className={css.left}>
+          <Link to={`/challenges/${slug}`} aria-label={title}>
+            {cover ? (
+              <Image
+                image={cover.file.childImageSharp.gatsbyImageData}
+                pictureClassName={css.picture}
+                imgClassName={css.image}
+                alt={`"${title}" challenge`}
+              />
+            ) : placeholderImage ? (
+              <Image
+                image={placeholderImage}
+                pictureClassName={css.picture}
+                imgClassName={css.image}
+                alt={`"${title}" challenge`}
+              />
+            ) : null}
+          </Link>
+          <p className={css.date}>
+            <span>
+              {date ? (
+                <time dateTime={date}>{getReadableDate(date)}</time>
+              ) : null}
+            </span>
+          </p>
         </div>
-      </article>
-    );
-  }
-);
+        <div className={css.right}>
+          <div className={css.description}>
+            <p>{description}</p>
+          </div>
+          <p className={css.date}>
+            <span>
+              {date ? (
+                <time dateTime={date}>{getReadableDate(date)}</time>
+              ) : null}
+            </span>
+          </p>
+        </div>
+      </div>
+    </article>
+  );
+};
+const MemoizedCard = memo(Card);
 
 const ChallengesPanel = ({
   challenges,
@@ -88,7 +92,7 @@ const ChallengesPanel = ({
       <div className={css.challenges}>
         {shownChallenges.map((challenge, key) => (
           <Fragment key={key}>
-            <Card
+            <MemoizedCard
               className={css.challenge}
               challenge={challenge}
               placeholderImage={placeholderImage}

--- a/src/components/ChallengesPanel.module.css
+++ b/src/components/ChallengesPanel.module.css
@@ -88,6 +88,7 @@
   border-bottom: var(--border-cyan);
   border-left: var(--border-cyan);
   line-height: var(--baseline-box);
+  min-height: var(--baseline);
   padding: 0 calc(var(--box-padding) / 2);
   border-bottom: var(--border);
   border-color: var(--cyan);

--- a/src/templates/challenge.js
+++ b/src/templates/challenge.js
@@ -88,7 +88,6 @@ const Challenge = ({ data }) => {
           <ChallengesPanel
             challenges={challenge.relatedChallenges}
             placeholderImage={challengesPlaceholder}
-            shuffle={true}
           />
         </>
       )}

--- a/src/templates/challenge.js
+++ b/src/templates/challenge.js
@@ -88,6 +88,7 @@ const Challenge = ({ data }) => {
           <ChallengesPanel
             challenges={challenge.relatedChallenges}
             placeholderImage={challengesPlaceholder}
+            randomize={true}
           />
         </>
       )}

--- a/src/templates/challenge.js
+++ b/src/templates/challenge.js
@@ -88,7 +88,7 @@ const Challenge = ({ data }) => {
           <ChallengesPanel
             challenges={challenge.relatedChallenges}
             placeholderImage={challengesPlaceholder}
-            randomize={true}
+            shuffle={true}
           />
         </>
       )}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -62,7 +62,6 @@ export const shuffledCopy = (array, shouldShuffle = true) => {
   if (!shouldShuffle) {
     return copy;
   }
-  console.log('shuffling...');
   for (let i = copy.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     const temp = copy[i];
@@ -73,16 +72,14 @@ export const shuffledCopy = (array, shouldShuffle = true) => {
 };
 
 /**
- * This hook allows us to know whether we're in the client hydration phase or in
- * the server side rendering phase.
+ * This hook allows us to know whether we're in SSR phase or in client hydration
+ * phase.
  *
- * @returns A boolean set to true only on client hydration phase and a key
- * which changes when the phase changes.
+ * @return {boolean} A boolean set to true only on SSR phase.
  * @see {@link https://blog.logrocket.com/fixing-gatsbys-rehydration-issue/}
  */
-export const useIsClient = () => {
-  const [isClient, setClient] = useState(false);
-  const key = isClient ? 'client' : 'server';
-  useEffect(() => setClient(true), []);
-  return { isClient, key };
+export const useIsSSR = () => {
+  const [isSSR, setIsSSR] = useState(true);
+  useEffect(() => setIsSSR(false), []);
+  return isSSR;
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -68,15 +68,16 @@ export const shuffleCopy = (array) => {
 };
 
 /**
- * This hook allows us to know whether we're in SSR phase or in client hydration
- * phase.
+ * This hook will return true for the first render on the server and for the
+ * first render on the client. Otherwhise, it will return false.
  *
- * @return booleans indicating whether we're in Server Side Rendering or
- * Client Side Rendering
- * @see {@link https://blog.logrocket.com/fixing-gatsbys-rehydration-issue/}
+ * This function encapsulates a hook so "rules of hooks" apply to it.
+ * @see {@link https://reactjs.org/docs/hooks-rules.html}
+ *
+ * @return {boolean} true on the first server side and client side render
  */
-export const useSSR = () => {
-  const [isServer, setIsServer] = useState(true);
-  useEffect(() => setIsServer(false), []);
-  return { isServer, isClient: !isServer };
+export const useIsFirstRender = () => {
+  const [isFirst, setIsFirst] = useState(true);
+  useEffect(() => setIsFirst(false), []);
+  return isFirst;
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -53,7 +53,7 @@ export const filteredPath = (resource, language, topic) => {
 /**
  * Returns a shuffled copy of the array using the Fisher-Yates algorithm.
  */
-export const shuffleCopy = (array) => {
+export const shuffledCopy = (array) => {
   const copy = [...array];
   for (let i = copy.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -55,13 +55,9 @@ export const filteredPath = (resource, language, topic) => {
  * Returns a shuffled copy of the array using the Fisher-Yates algorithm.
  *
  * @param {any[]} array Array to be copied and shuffled
- * @param {boolean} shouldShuffle Indicates whether the array should be shuffled
  */
-export const shuffledCopy = (array, shouldShuffle = true) => {
+export const shuffleCopy = (array) => {
   const copy = [...array];
-  if (!shouldShuffle) {
-    return copy;
-  }
   for (let i = copy.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     const temp = copy[i];
@@ -75,11 +71,12 @@ export const shuffledCopy = (array, shouldShuffle = true) => {
  * This hook allows us to know whether we're in SSR phase or in client hydration
  * phase.
  *
- * @return {boolean} A boolean set to true only on SSR phase.
+ * @return booleans indicating whether we're in Server Side Rendering or
+ * Client Side Rendering
  * @see {@link https://blog.logrocket.com/fixing-gatsbys-rehydration-issue/}
  */
-export const useIsSSR = () => {
-  const [isSSR, setIsSSR] = useState(true);
-  useEffect(() => setIsSSR(false), []);
-  return isSSR;
+export const useSSR = () => {
+  const [isServer, setIsServer] = useState(true);
+  useEffect(() => setIsServer(false), []);
+  return { isServer, isClient: !isServer };
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -49,3 +49,17 @@ export const filteredPath = (resource, language, topic) => {
     stringValueOrAll(language)
   )}/topic/${toSlug(stringValueOrAll(topic))}`;
 };
+
+/**
+ * Returns a shuffled copy of the array using the Fisher-Yates algorithm.
+ */
+export const shuffleCopy = (array) => {
+  const copy = [...array];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const temp = copy[i];
+    copy[i] = copy[j];
+    copy[j] = temp;
+  }
+  return copy;
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import slugify from 'slugify';
 
 // so it doesn't throw if no window
@@ -52,9 +53,16 @@ export const filteredPath = (resource, language, topic) => {
 
 /**
  * Returns a shuffled copy of the array using the Fisher-Yates algorithm.
+ *
+ * @param {any[]} array Array to be copied and shuffled
+ * @param {boolean} shouldShuffle Indicates whether the array should be shuffled
  */
-export const shuffledCopy = (array) => {
+export const shuffledCopy = (array, shouldShuffle = true) => {
   const copy = [...array];
+  if (!shouldShuffle) {
+    return copy;
+  }
+  console.log('shuffling...');
   for (let i = copy.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     const temp = copy[i];
@@ -62,4 +70,19 @@ export const shuffledCopy = (array) => {
     copy[j] = temp;
   }
   return copy;
+};
+
+/**
+ * This hook allows us to know whether we're in the client hydration phase or in
+ * the server side rendering phase.
+ *
+ * @returns A boolean set to true only on client hydration phase and a key
+ * which changes when the phase changes.
+ * @see {@link https://blog.logrocket.com/fixing-gatsbys-rehydration-issue/}
+ */
+export const useIsClient = () => {
+  const [isClient, setClient] = useState(false);
+  const key = isClient ? 'client' : 'server';
+  useEffect(() => setClient(true), []);
+  return { isClient, key };
 };


### PR DESCRIPTION
Hi! The "Try a Challenge!" section on a challenge page only shows the first 2 challenges from the "relatedChallenges" array. So putting more than 2 challenges in this array seems kind of odd. Unless we randomize the challenges that are shown on the page.

So this is my suggestion :smile:  I don't know if that's a good idea. One drawback of this is that this doesn't seem to work great with SSG (Static Site Generation).

Preview example : https://deploy-preview-572--codingtrain.netlify.app/challenges/162-self-avoiding-walk