### PR TITLE
Add submittedOn field to showcase contributions

### DIFF
--- a/content-testing/file-formats.js
+++ b/content-testing/file-formats.js
@@ -155,7 +155,8 @@ const contribution = {
       },
       url: { type: 'string' },
       source: { type: 'string' },
-      videoId: { type: 'string' }
+      videoId: { type: 'string' },
+      submittedOn: { type: 'string' }
     }
   }
 };

--- a/content/templates/showcase/contribution1.json
+++ b/content/templates/showcase/contribution1.json
@@ -4,5 +4,6 @@
   "author": {
     "name": "Your Name (or nickname!)",
     "url": "Link to more about you! (personal site, GitHub, social media, etc.)"
-  }
+  },
+  "submittedOn": "YYYY-MM-DD (optional)" 
 }

--- a/content/templates/showcase/contribution1.json
+++ b/content/templates/showcase/contribution1.json
@@ -5,5 +5,5 @@
     "name": "Your Name (or nickname!)",
     "url": "Link to more about you! (personal site, GitHub, social media, etc.)"
   },
-  "submittedOn": "YYYY-MM-DD (optional)" 
+  "submittedOn": "YYYY-MM-DD"
 }

--- a/content/templates/videos/contribution1.json
+++ b/content/templates/videos/contribution1.json
@@ -1,10 +1,9 @@
 {
-  "title": "Contribution title",
+  "title": "Project Title",
+  "url": "Project URL",
   "author": {
-    "name": "Author name",
-    "url": "Author url to own website or GitHub"
+    "name": "Your Name (or nickname!)",
+    "url": "Link to more about you! (personal site, GitHub, social media, etc.)"
   },
-  "url": "URL to live code of contribution",
-  "videoId": "YouTube video ID to video of contribution",
-  "source": "URL to source code of contribution"
+  "submittedOn": "YYYY-MM-DD"
 }

--- a/netlify/functions/submission-background.js
+++ b/netlify/functions/submission-background.js
@@ -62,7 +62,8 @@ exports.handler = async function (event) {
     author: {
       name: postInfo.authorName
     },
-    url: postInfo.url
+    url: postInfo.url,
+    submittedOn: new Date().toISOString().split('T')[0]
   };
 
   if (postInfo.authorUrl) {


### PR DESCRIPTION
Added field `submittedOn` to showcase submissions, as proposed in https://github.com/CodingTrain/thecodingtrain.com/issues/569#issuecomment-1256380913.

This field contains only the date (not time) of execution of the `submission-background` netlify function.

Let me know if any changes are required!