### PR TITLE
Multiple Featured Showcase on the Homepage

### DIFF
--- a/content/pages/homepage/index.json
+++ b/content/pages/homepage/index.json
@@ -48,7 +48,7 @@
     }
   },
   "passengerShowcase": {
-    "title": "Passenger showcase highlight",
+    "title": "Passenger showcase highlights",
     "featured": [
       "challenges/76-10Print/showcase/contribution41.json",
       "challenges/126-toothpicks/showcase/contribution1.json",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -107,16 +107,26 @@ const PassengerShowcaseCard = ({ showcase, placeholderImage, cta }) => {
           </p>
           <p className={css.showcaseTitle}>{title}</p>
         </div>
-        <address className={css.author}>
-          {author?.url ? <a href={author.url}>{author?.name}</a> : author?.name}
-        </address>
+        <p className={css.author}>
+          {author && <span>by </span>}
+          {author && (
+            <address>
+              {author.url ? (
+                <a href={author.url}>{author.name}</a>
+              ) : (
+                author.name
+              )}
+            </address>
+          )}
+        </p>
       </div>
       <a
         className={css.right}
         href={buttonLink}
         target="_blank"
         rel="noreferrer"
-        aria-label={description}>
+        aria-label={description}
+      >
         {image ? (
           <Image
             image={image}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -107,18 +107,18 @@ const PassengerShowcaseCard = ({ showcase, placeholderImage, cta }) => {
           </p>
           <p className={css.showcaseTitle}>{title}</p>
         </div>
-        <p className={css.author}>
+        <address className={css.author}>
           {author && <span>by </span>}
           {author && (
-            <address>
+            <span className={css.authorName}>
               {author.url ? (
                 <a href={author.url}>{author.name}</a>
               ) : (
                 author.name
               )}
-            </address>
+            </span>
           )}
-        </p>
+        </address>
       </div>
       <a
         className={css.right}
@@ -162,14 +162,14 @@ const PassengerShowcaseSection = ({ passengerShowcase, placeholderImage }) => {
       <p className={css.showcaseBanner}>{cta.text}</p>
       <Spacer className={css.verticalSpacer} pattern />
       {featuredShowcases.map((showcase, index) => (
-        <>
+        <React.Fragment key={index}>
           <PassengerShowcaseCard
             showcase={showcase}
             placeholderImage={placeholderImage}
             cta={cta}
           />
           {index < 2 && <Spacer className={css.verticalSpacer} pattern />}
-        </>
+        </React.Fragment>
       ))}
     </section>
   );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -16,8 +16,9 @@ import SemiColonCharacter from '../images/characters/SemiColon_1.mini.svg';
 
 import * as css from '../styles/pages/index.module.css';
 import Button from '../components/Button';
+import PlayButton from '../images/playbutton.svg';
 import { getReadableDate, useIsFirstRender } from '../hooks';
-import { randomElement, shuffleCopy } from '../utils';
+import { shuffleCopy } from '../utils';
 
 const TrackCard = ({ track, placeholderImage }) => {
   const { title, cover, date, numVideos, slug } = track;
@@ -95,47 +96,39 @@ const PassengerShowcaseCard = ({ showcase, placeholderImage, cta }) => {
     : placeholderImage;
   const buttonLink =
     url ?? (videoId ? `https://youtu.be/${videoId}` : source) ?? '';
+  const description = `Passenger showcase "${title}" from ${author?.name}`;
 
   return (
     <article className={css.showcase}>
       <div className={css.left}>
         <div className={css.details}>
-          <p>
-            <address>
-              {author?.url ? (
-                <a href={author.url}>{author?.name}</a>
-              ) : (
-                author?.name
-              )}
-            </address>
-          </p>
-          <p>{title}</p>
-          <p>
+          <p className={css.videoTitle}>
             {video?.title} {video?.source && `(${video.source})`}
           </p>
+          <p className={css.showcaseTitle}>{title}</p>
         </div>
-        <ButtonPanel
-          variant="purple"
-          className={css.baselineButtonPanel}
-          text={cta?.text}
-          buttonText={cta?.buttonText}
-          buttonLink={buttonLink}
-          smallWrap
-          rainbow
-        />
+        <address className={css.author}>
+          {author?.url ? <a href={author.url}>{author?.name}</a> : author?.name}
+        </address>
       </div>
-      <div className={css.right}>
+      <a
+        className={css.right}
+        href={buttonLink}
+        target="_blank"
+        rel="noreferrer"
+        aria-label={description}>
         {image ? (
           <Image
             image={image}
             pictureClassName={css.picture}
             imgClassName={css.image}
-            alt={`Passenger showcase "${title}" from ${author?.name}`}
+            alt={description}
           />
         ) : (
           <div className={css.noImage}></div>
         )}
-      </div>
+        <PlayButton width={30} className={css.playButton} />
+      </a>
     </article>
   );
 };
@@ -156,12 +149,17 @@ const PassengerShowcaseSection = ({ passengerShowcase, placeholderImage }) => {
           {sectionTitle}
         </Heading2>
       </div>
-      {featuredShowcases.map((showcase) => (
-        <PassengerShowcaseCard
-          showcase={showcase}
-          placeholderImage={placeholderImage}
-          cta={cta}
-        />
+      <p className={css.showcaseBanner}>{cta.text}</p>
+      <Spacer className={css.verticalSpacer} pattern />
+      {featuredShowcases.map((showcase, index) => (
+        <>
+          <PassengerShowcaseCard
+            showcase={showcase}
+            placeholderImage={placeholderImage}
+            cta={cta}
+          />
+          {index < 2 && <Spacer className={css.verticalSpacer} pattern />}
+        </>
       ))}
     </section>
   );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -88,71 +88,81 @@ const ChallengeCard = ({ challenge, placeholderImage }) => {
   );
 };
 
-const PassengerShowcaseSection = ({ passengerShowcase, placeholderImage }) => {
-  const { title: sectionTitle, cta, featured } = passengerShowcase;
-  // First render : empty placeholder
-  const [featuredShowcase, setFeaturedShowcase] = useState({});
-  useEffect(() => {
-    // Next renders : a random passenger showcase
-    setFeaturedShowcase(randomElement(featured));
-  }, [featured]);
-
-  const { author, title, video, videoId, url, source } = featuredShowcase;
-  const image = featuredShowcase?.cover
-    ? featuredShowcase.cover.file.childImageSharp.gatsbyImageData
+const PassengerShowcaseCard = ({ showcase, placeholderImage, cta }) => {
+  const { author, title, video, videoId, url, source } = showcase;
+  const image = showcase?.cover
+    ? showcase.cover.file.childImageSharp.gatsbyImageData
     : placeholderImage;
   const buttonLink =
     url ?? (videoId ? `https://youtu.be/${videoId}` : source) ?? '';
 
   return (
-    <section>
-      <article className={css.showcase}>
-        <div className={css.left}>
-          <Heading2
-            id="passenger-showcase"
-            className={css.subheading}
-            variant="purple"
-            as="h3">
-            {sectionTitle}
-          </Heading2>
-          <div className={css.details}>
-            <p>
-              <address>
-                {author?.url ? (
-                  <a href={author.url}>{author?.name}</a>
-                ) : (
-                  author?.name
-                )}
-              </address>
-            </p>
-            <p>{title}</p>
-            <p>
-              {video?.title} {video?.source && `(${video.source})`}
-            </p>
-          </div>
-          <ButtonPanel
-            variant="purple"
-            className={css.baselineButtonPanel}
-            text={cta?.text}
-            buttonText={cta?.buttonText}
-            buttonLink={buttonLink}
-            smallWrap
-            rainbow
+    <article className={css.showcase}>
+      <div className={css.left}>
+        <div className={css.details}>
+          <p>
+            <address>
+              {author?.url ? (
+                <a href={author.url}>{author?.name}</a>
+              ) : (
+                author?.name
+              )}
+            </address>
+          </p>
+          <p>{title}</p>
+          <p>
+            {video?.title} {video?.source && `(${video.source})`}
+          </p>
+        </div>
+        <ButtonPanel
+          variant="purple"
+          className={css.baselineButtonPanel}
+          text={cta?.text}
+          buttonText={cta?.buttonText}
+          buttonLink={buttonLink}
+          smallWrap
+          rainbow
+        />
+      </div>
+      <div className={css.right}>
+        {image ? (
+          <Image
+            image={image}
+            pictureClassName={css.picture}
+            imgClassName={css.image}
+            alt={`Passenger showcase "${title}" from ${author?.name}`}
           />
-        </div>
-        <div className={css.right}>
-          {image ? (
-            <Image
-              image={image}
-              pictureClassName={css.picture}
-              imgClassName={css.image}
-              alt={`Passenger showcase "${title}" from ${author?.name}`}
-            />
-          ) : (
-            <div className={css.noImage}></div>
-          )}
-        </div>
-      </article>
+        ) : (
+          <div className={css.noImage}></div>
+        )}
+      </div>
+    </article>
+  );
+};
+
+const PassengerShowcaseSection = ({ passengerShowcase, placeholderImage }) => {
+  const { title: sectionTitle, cta, featured } = passengerShowcase;
+  // First render : empty placeholder
+  const [featuredShowcases, setFeaturedShowcases] = useState([{}, {}, {}]);
+  useEffect(() => {
+    // Next renders : a random passenger showcase
+    setFeaturedShowcases(shuffleCopy(featured).slice(0, 3));
+  }, [featured]);
+
+  return (
+    <section>
+      <div className={css.subheader}>
+        <Heading2 className={css.subheading} variant="purple">
+          {sectionTitle}
+        </Heading2>
+      </div>
+      {featuredShowcases.map((showcase) => (
+        <PassengerShowcaseCard
+          showcase={showcase}
+          placeholderImage={placeholderImage}
+          cta={cta}
+        />
+      ))}
     </section>
   );
 };

--- a/src/styles/pages/index.module.css
+++ b/src/styles/pages/index.module.css
@@ -220,19 +220,28 @@
   border-left: var(--border-cyan);
 }
 
+.showcaseBanner {
+  margin: 0;
+  padding: 0 var(--box-padding);
+  border-bottom: var(--border-purple);
+  border-left: var(--border-purple);
+  line-height: var(--baseline-box);
+  font-size: var(--maru-large);
+  color: var(--gray-dark);
+  background-color: var(--purple-light);
+  text-transform: uppercase;
+}
+
 .showcase {
   display: flex;
 }
 
 .showcase .left {
-  flex: 75%;
+  flex: 60%;
 }
 
 .showcase .right {
-  flex: 25%;
-}
-
-.showcase .right {
+  flex: 40%;
   display: flex;
   align-items: stretch;
 }
@@ -241,16 +250,42 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  height: var(--baseline-3x);
+  height: var(--baseline-2x);
   border-left: var(--border);
-  border-bottom: var(--border);
+  border-bottom: var(--border-purple);
   background: white;
+
+  & p {
+    margin: 0;
+    padding: 0 var(--box-padding);
+    color: var(--gray-dark);
+  }
+
+  & .showcaseTitle {
+    font-family: var(--maru-mono);
+    font-size: var(--maru-xlarge);
+    line-height: var(--maru-xlarge-line-height);
+    font-weight: bold;
+  }
+
+  & .videoTitle {
+    text-transform: uppercase;
+    font-size: var(--maru-normal);
+    color: var(--gray-mid);
+  }
 }
 
-.showcase .left .details p {
-  margin: 0;
+.showcase .author {
+  color: var(--purple);
   padding: 0 var(--box-padding);
-  color: var(--gray-dark);
+  line-height: var(--baseline-box);
+  border-bottom: var(--border-purple);
+  border-left: var(--border-purple);
+
+  &::before {
+    content: "by ";
+    color: var(--gray-dark);
+  }
 }
 
 .showcase .right .picture {
@@ -265,9 +300,19 @@
     border-left: var(--border);
     border-bottom: var(--border);
     width: 100%;
-    height: var(--baseline-4x);
+    height: var(--baseline-3x);
     background-color: var(--gray-light);
   }
+}
+
+.showcase a {
+  position: relative;
+}
+
+.showcase .playButton {
+  position: absolute;
+  bottom: calc(var(--box-padding) / 4);
+  right: calc(var(--box-padding) / 4);
 }
 
 .eventsBanner {

--- a/src/styles/pages/index.module.css
+++ b/src/styles/pages/index.module.css
@@ -265,7 +265,7 @@
     border-left: var(--border);
     border-bottom: var(--border);
     width: 100%;
-    height: var(--baseline-5x);
+    height: var(--baseline-4x);
     background-color: var(--gray-light);
   }
 }

--- a/src/styles/pages/index.module.css
+++ b/src/styles/pages/index.module.css
@@ -255,7 +255,7 @@
   border-bottom: var(--border-purple);
   background: white;
 
-  & p {
+  & p, & address {
     margin: 0;
     padding: 0 var(--box-padding);
     color: var(--gray-dark);
@@ -277,6 +277,7 @@
 
 .showcase .author {
   font-family: var(--maru-mono);
+  font-style: normal;
   color: var(--gray-dark);
   padding: 0 var(--box-padding);
   margin: 0;
@@ -285,10 +286,9 @@
   border-bottom: var(--border-purple);
   border-left: var(--border-purple);
 
-  & address {
+  & .authorName {
     display: inline;
     color: var(--purple);
-    font-style: normal;
 
     & a {
       text-decoration: underline;

--- a/src/styles/pages/index.module.css
+++ b/src/styles/pages/index.module.css
@@ -261,17 +261,17 @@
     color: var(--gray-dark);
   }
 
+  & .videoTitle {
+    text-transform: uppercase;
+    font-size: var(--maru-normal);
+    color: var(--gray-mid);
+  }
+
   & .showcaseTitle {
     font-family: var(--maru-mono);
     font-size: var(--maru-xlarge);
     line-height: var(--maru-xlarge-line-height);
     font-weight: bold;
-  }
-
-  & .videoTitle {
-    text-transform: uppercase;
-    font-size: var(--maru-normal);
-    color: var(--gray-mid);
   }
 }
 
@@ -281,6 +281,7 @@
   line-height: var(--baseline-box);
   border-bottom: var(--border-purple);
   border-left: var(--border-purple);
+  font-style: normal;
 
   &::before {
     content: "by ";

--- a/src/styles/pages/index.module.css
+++ b/src/styles/pages/index.module.css
@@ -276,16 +276,23 @@
 }
 
 .showcase .author {
-  color: var(--purple);
+  font-family: var(--maru-mono);
+  color: var(--gray-dark);
   padding: 0 var(--box-padding);
+  margin: 0;
   line-height: var(--baseline-box);
+  height: var(--baseline);
   border-bottom: var(--border-purple);
   border-left: var(--border-purple);
-  font-style: normal;
 
-  &::before {
-    content: "by ";
-    color: var(--gray-dark);
+  & address {
+    display: inline;
+    color: var(--purple);
+    font-style: normal;
+
+    & a {
+      text-decoration: underline;
+    }
   }
 }
 
@@ -481,7 +488,7 @@
   .showcase .right {
     & .image,
     & .noImage {
-      height: var(--baseline-8x);
+      height: var(--baseline-6x);
     }
   }
   .event {


### PR DESCRIPTION
Hi! :steam_locomotive:  This PR implements a part of issue #590. It's a rework on the Passenger Showcase Highlight section on the Homepage. The goal is to display three contributions instead of one.

The simplest way to stack 3 contributions woud be to do this :
![version1](https://user-images.githubusercontent.com/37326143/195713651-69ba0337-bf32-4e0d-b42f-2dae23354e6b.png)

I worked a bit more on this design so that it fits better with the rest of the page : 
1. I used a bigger font-size for the "PASSENGER SHOWCASE HIGHLIGHT" title do that it fits better with the rest of the titles on the Homepage ;
2. I replaced the three "READY TO BE INSPIRED?" banners with only one at the top to avoid duplication and to avoid having three big CTA buttons at the same place ;
3. I added hierarchy on the details of the contribution by playing with the font sizes and colors : I emphasized the title of the contribution, then the author and finally the source video ;
4. I let the image take 40% percent of the width instead of 25%, so fill the empty space an give more presence and a "cinematic" feel to the image ;
5. To replace the CTA, I added a play button in the corner of the images, just like on the challenge and track video pages, this also adds consistency.

![version2](https://user-images.githubusercontent.com/37326143/195949455-39cf7275-dbd7-431b-b42a-b6cbd6f386fd.png)
Preview : https://deploy-preview-665--codingtrain.netlify.app/

These are only ideas and I'm open to any rework. Feel free to give me your opinion on these changes :smiley: @shiffman @runemadsen 