### PR TITLE
Fix height of passenger showcase details on homepage

### DIFF
--- a/src/styles/pages/index.module.css
+++ b/src/styles/pages/index.module.css
@@ -249,7 +249,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  height: var(--baseline-2x);
+  height: var(--baseline-3x);
   border-left: var(--border);
   border-bottom: var(--border-purple);
   background: white;
@@ -307,7 +307,7 @@
     border-left: var(--border);
     border-bottom: var(--border);
     width: 100%;
-    height: var(--baseline-3x);
+    height: var(--baseline-4x);
     background-color: var(--gray-light);
   }
 }


### PR DESCRIPTION
Hi :steam_locomotive: I just noticed some overflow on the title of passenger showcases on the homepage (PR #665). Here's a fix :

Wide screen (before)
![wide-before](https://user-images.githubusercontent.com/37326143/197256608-6e298bb9-18a4-42f5-b101-549826f3c751.png)
Wide screen (after)
![wide-after](https://user-images.githubusercontent.com/37326143/197256603-4df6e7d5-287e-4602-847b-1dc68a8bc9ee.png)

Medium screen (before)
![medium-before](https://user-images.githubusercontent.com/37326143/197256595-601d1f05-1c62-4b51-83b9-3b1dbc05072c.png)
Medium screen (after)
![medium-after](https://user-images.githubusercontent.com/37326143/197256588-e6cf3952-6a26-4eb2-a36a-edb3a9621536.png)

Small screen (before)
![small-before](https://user-images.githubusercontent.com/37326143/197256600-04acbb2c-ccfa-409d-8892-3e2ed85674a3.png)
Small screen (after)
![small-after](https://user-images.githubusercontent.com/37326143/197256598-0956e865-b92d-4f29-a90e-fb316047e181.png)