### PR TITLE
Adding links to livestream archive  and adding more  related challenges 

### DIFF
--- a/content/videos/challenges/104-linear-regression-with-tensorflowjs/index.json
+++ b/content/videos/challenges/104-linear-regression-with-tensorflowjs/index.json
@@ -11,7 +11,7 @@
         "stochastic gradient descent"
     ],
     "canContribute": true,
-    "relatedChallenges": [],
+    "relatedChallenges": ["70-nearest-neighbors-recommendation-engine", "105-polynomial-regression-with-tensorflowjs", "106-xor-problem-with-tensorflowjs"],
     "timestamps": [
         { "time": "0:00", "title": "Introduction" },
         { "time": "1:21", "title": "What is linear regression?" },
@@ -91,6 +91,22 @@
                     "description": "What is a JavaScript Promise?"
                 }
             ]
-        }
+        },
+        {
+            "title": "Live Stream Archives",
+            "links": [{
+                    "icon": "🔴",
+                    "title": "Live Stream #93",
+                    "url": "https://youtu.be/5zbF3VXAAto",
+                    "description": "Session 3 of “Intelligence and Learning” Continued"
+                },
+                {
+                    "icon": "🔴",
+                    "title": "Live Stream #94",
+                    "url": "https://youtu.be/S6NQFDZkRMo",
+                    "description": "Session 3 of “Intelligence and Learning” - Part 3"
+                }
+            ]
+        }   
     ]
 }

--- a/content/videos/challenges/26-3d-supershapes/index.json
+++ b/content/videos/challenges/26-3d-supershapes/index.json
@@ -12,7 +12,7 @@
     { "time": "0:00", "title": "Introduction" },
     { "time": "0:44", "title": "Reza Ali's generative art" },
     { "time": "1:04", "title": "Paul Bourke's website" },
-    { "time": "152", "title": "Constants" },
+    { "time": "1:52", "title": "Constants" },
     { "time": "4:46", "title": "Supershape function" },
     { "time": "6:58", "title": "Why do we have r1 and r2?" },
     { "time": "11:23", "title": "Work on the math" },

--- a/content/videos/challenges/3-snake-game/index.json
+++ b/content/videos/challenges/3-snake-game/index.json
@@ -7,7 +7,7 @@
   "languages": ["p5.js", "JavaScript"],
   "topics": ["snake", "game", "vectors", "arrays"],
   "canContribute": true,
-  "relatedChallenges": ["173-snake-applesoft-basic"],
+  "relatedChallenges": ["173-snake-applesoft-basic", "115-snake-game-redux"],
   "timestamps": [
     { "time": "0:00", "title": "Creating a Snake object" },
     { "time": "3:00", "title": "Adding keyboard control" },

--- a/content/videos/challenges/3-snake-game/index.json
+++ b/content/videos/challenges/3-snake-game/index.json
@@ -7,7 +7,7 @@
   "languages": ["p5.js", "JavaScript"],
   "topics": ["snake", "game", "vectors", "arrays"],
   "canContribute": true,
-  "relatedChallenges": ["173-snake-applesoft-basic", "115-snake-game-redux"],
+  "relatedChallenges": ["32-agario", "72-frogger", "173-snake-applesoft-basic", "115-snake-game-redux"],
   "timestamps": [
     { "time": "0:00", "title": "Creating a Snake object" },
     { "time": "3:00", "title": "Adding keyboard control" },
@@ -43,16 +43,10 @@
       ]
     },
     {
-      "title": "Videos",
+      "title": "Live Stream Archive",
       "links": [
         {
-          "icon": "🎥",
-          "title": "Snake Game Redux Coding Challenge",
-          "url": "https://www.youtube.com/watch?v=OMoVcohRgZA",
-          "description": "Snake Game!?!? Again!? Now with the p5.js Web Editor!"
-        },
-        {
-          "icon": "🎥",
+          "icon": "🔴",
           "title": "Live Stream #32",
           "url": "https://www.youtube.com/watch?v=yUO2bWfBgN8&t=2340s",
           "description": "In this video, I code a p5.js version of the Snake Game in another installment of the 10 Minute Coding Challenge."

--- a/content/videos/challenges/30-phyllotaxis/index.json
+++ b/content/videos/challenges/30-phyllotaxis/index.json
@@ -78,12 +78,6 @@
            "description": "Golan Levin visits the Coding Train studio for a tutorial about the modulo operator."
        },
        {
-          "icon": "🎥",
-          "title": "Algorithmic Botany Track",
-          "url": "/tracks/algorithmic-botany",
-          "description": "This side track explores patterns found in nature. We'll cover how to simulate growing plants, flowers, and trees in p5.js and Processing."
-        },
-        {
           "icon": "🔴",
           "title": "Live Stream Archive #54",
           "url": "https://youtu.be/MQMJ0xWSMWE",

--- a/content/videos/challenges/32-agario/index.json
+++ b/content/videos/challenges/32-agario/index.json
@@ -143,6 +143,17 @@
             ]
         },
         {
+            "title": "Videos",
+            "links": [
+                {
+                    "icon": "🚂",
+                    "title": "Collaborative p5.js Sketches Channel",
+                    "url": "https://www.youtube.com/playlist?list=PLRqwX-V7Uu6b36TzJidYfIYwTFEq3K5qH",
+                    "description": "My playlist which covers how to use node.js, p5.js, and socket.io (websockets) to create a shared HTML5 canvas across multiple browser sessions."
+                }
+            ]
+        },
+        {
             "title": "Livestream Archive",
             "links": [
                 {

--- a/content/videos/challenges/35-traveling-salesperson/index.json
+++ b/content/videos/challenges/35-traveling-salesperson/index.json
@@ -278,12 +278,22 @@
           "title": "Genetic Algorithm Playlist",
           "url": "https://www.youtube.com/playlist?list=PLRqwX-V7Uu6bJM3VgzjNV5YxVxUwzALHV",
           "description": "A Coding Train YouTube playlist about Genetic Algorithms."
+        }
+      ]
+    },
+    {
+      "title": "Live Stream Archives",
+      "links": [{
+          "icon": "🔴",
+          "title": "Livestream #57",
+          "url": "https://youtu.be/r_SpBy9fQuo",
+          "description": "Livestream with Traveling Salesperson."
         },
         {
           "icon": "🔴",
-          "title": "Live Stream Archive #57",
-          "url": "https://youtu.be/r_SpBy9fQuo",
-          "description": "Livestream with Traveling Salesperson."
+          "title": "Live Stream #90",
+          "url": "https://youtu.be/NCvdjnN9UfI",
+          "description": "Livestream with Traveling Sales Person with Genetic Algorithm"
         }
       ]
     }

--- a/content/videos/challenges/39-madlibs-generator/index.json
+++ b/content/videos/challenges/39-madlibs-generator/index.json
@@ -7,7 +7,7 @@
   "languages": ["JavaScript", "p5.js", "tabletop.js"],
   "topics": ["mad libs", "google forms", "data collecting"],
   "canContribute": true,
-  "relatedChallenges": ["37-diastic-machine"],
+  "relatedChallenges": ["37-diastic-machine", "39-madlibs-generator", "42-markov-chain-name-generator"],
   "timestamps": [
       { "time": "0:00", "title": "Introduction and what Mad Libs is" },
       { "time": "2:15", "title": "Making the Google Form" },

--- a/content/videos/challenges/42-markov-chain-name-generator/index.json
+++ b/content/videos/challenges/42-markov-chain-name-generator/index.json
@@ -11,7 +11,7 @@
         "text generator"
     ],
     "canContribute": true,
-    "relatedChallenges": [],
+    "relatedChallenges": ["37-diastic-machine", "39-madlibs-generator"],
     "timestamps": [],
     "parts": [
         {

--- a/content/videos/challenges/62-plinko-with-matterjs/index.json
+++ b/content/videos/challenges/62-plinko-with-matterjs/index.json
@@ -126,6 +126,12 @@
           "title": "Inheritance with Prototype in JavaScript",
           "url": "https://www.youtube.com/watch?v=CpmE5twq1h0",
           "description": "In this video, I discuss how inheritance works with prototypes in JS."
+        },
+        {
+          "icon": "🔴",
+          "title": "Live Stream #84",
+          "url": "https://youtu.be/Iu3M-X1yRFU",
+          "description": "Live Stream with Plinko with Matter.js"
         }
       ]
     }

--- a/content/videos/challenges/68-breadth-first-search/index.json
+++ b/content/videos/challenges/68-breadth-first-search/index.json
@@ -104,6 +104,12 @@
           "title": "My Video on Prototypes",
           "url": "https://www.youtube.com/watch?v=hS_WqkyUah8",
           "description": "In this video, I examine the concept of \"Prototype\" in the JavaScript programming language."
+        },
+        {
+          "icon": "🔴",
+          "title": "Live Stream Archive #88",
+          "url": "https://youtu.be/YUlJAu1j_UM",
+          "description": "Session 1 of “Intelligence and Learning and breadth-first-search"
         }
       ]
     }

--- a/content/videos/challenges/69-evolutionary-steering-behaviors/index.json
+++ b/content/videos/challenges/69-evolutionary-steering-behaviors/index.json
@@ -144,6 +144,12 @@
                     "title": "My Video on How to go Through an Array Backwards",
                     "url": "https://youtu.be/HXOD_XDA-KU",
                     "description": "This video looks at how to delete objects from an array selectively."
+                },
+                {
+                    "icon": "🔴",
+                    "title": "Live Stream Archive #89",
+                    "url": "https://youtu.be/qzFlnX-z38U",
+                    "description": "Session 2 of Intelligence and Learning"
                 }
             ]
         }

--- a/content/videos/challenges/70-nearest-neighbors-recommendation-engine/index.json
+++ b/content/videos/challenges/70-nearest-neighbors-recommendation-engine/index.json
@@ -12,7 +12,7 @@
     "associative arrays"
   ],
   "canContribute": true,
-  "relatedChallenges": [],
+  "relatedChallenges": ["98-quadtree", "104-linear-regression-with-tensorflowjs", "105-polynomial-regression-with-tensorflowjs"],
   "timestamps": [],
   "parts": [
     {
@@ -141,6 +141,12 @@
           "title": "My Video on Associative Arrays",
           "url": "https://www.youtube.com/watch?v=_5jdE6RKxVk",
           "description": "In this video, I discuss the concept of \"associative arrays\" in JavaScript."
+        },
+        {
+          "icon": "🔴",
+          "title": "Live Stream Archive #91",
+          "url": "https://youtu.be/Do_Gftp_oug",
+          "description": "Session 3 of Intelligence and Learning"
         }
       ]
     }

--- a/content/videos/challenges/77-recursion/index.json
+++ b/content/videos/challenges/77-recursion/index.json
@@ -48,6 +48,12 @@
           "icon": "🎥",
           "title": "My playlist on fractals & recursion",
           "url": "https://www.youtube.com/playlist?list=PLRqwX-V7Uu6bXUJvjnMWGU5SmjhI-OXef"
+        },
+        {
+          "icon": "🔴",
+          "title": "Live Stream Archive #102",
+          "url": "https://youtu.be/-RvrDZd1xVw",
+          "description": "Intro to ES6 Classes - OOP in JavaScript"
         }
       ]
     }

--- a/content/videos/challenges/78-simple-particle-system/index.json
+++ b/content/videos/challenges/78-simple-particle-system/index.json
@@ -68,6 +68,12 @@
                     "title": "Particle Systems playlist",
                     "url": "https://www.youtube.com/playlist?list=PLRqwX-V7Uu6Z9hI4mSgx2FlE5w8zvjmEy",
                     "description": "Video lessons accompanying Chapter 4 (Particle Systems) from The Nature of Code book."
+                },
+                {
+                    "icon": "🔴",
+                    "title": "Live Stream #103",
+                    "url": "https://youtu.be/Pscq691SADc",
+                    "description": "Live Stream with More on JavaScript Objects & Chatbots with RiveScript"
                 }
             ]
         }

--- a/content/videos/challenges/81-circle-morphing/index.json
+++ b/content/videos/challenges/81-circle-morphing/index.json
@@ -104,6 +104,16 @@
 ],
     "groupLinks": [
         {
+            "title": "References",
+            "links": [
+              {
+                "title": "Golan Levin's GitHub repo on Circle Morphing",
+                "url": "https://github.com/golanlevin/circle-morphing",
+                "description": "GitHub repo with different ways to morph a circle into a square."
+              }
+            ]
+        },
+        {
             "title": "Videos",
             "links": [{
                    "icon": "🎥",

--- a/content/videos/challenges/91-snakes-and-ladders/index.json
+++ b/content/videos/challenges/91-snakes-and-ladders/index.json
@@ -7,7 +7,7 @@
   "languages": ["p5.js", "JavaScript"],
   "topics": ["snakes and ladders", "game"],
   "canContribute": true,
-  "relatedChallenges": [],
+  "relatedChallenges": ["71-minesweeper", "72-frogger", "94-2048"],
   "timestamps": [],
   "parts": [
     {


### PR DESCRIPTION
Adding Live Stream archive links:  35, 62, 68, 69, 77, 78, 91

Adding relatedChallenges to 3, 39,42,70,91

104 - both livestream archive link and related challenge 

26- fix typo

81- Add link to Golan Levin's repo that was in yt-desc and missing from json

30- remove duplicate link

32 - add link to collaborative sketches playlist in yt-desc

3- updated json (moved moved ported challenge from videos to related challenges