### PR TITLE
Remove # from YT description

### DIFF
--- a/node-scripts/yt-description.js
+++ b/node-scripts/yt-description.js
@@ -350,7 +350,7 @@ function writeDescription(video) {
         const { videoNumber, challengeTitle } = challengeData.data;
         const url = challengeData.pageURL;
         description +=
-          `🚂 #${videoNumber} ${challengeTitle}: ${resolveYTLink(url)}` + '\n';
+          `🚂 ${videoNumber} ${challengeTitle}: ${resolveYTLink(url)}` + '\n';
       } else {
         console.log(`Challenge ${challenge} not found`);
       }


### PR DESCRIPTION
<img width="361" alt="Screen Shot 2022-11-11 at 3 56 24 PM" src="https://user-images.githubusercontent.com/191758/201429724-af00812e-79d3-4d51-8f8b-f4a1dd5a3581.png">

Noticed the challenge numbers were causing this issue ⬆️