### PR TITLE
Build performance improvements

### DIFF
--- a/content/videos/challenges/153-interactive-drawing-with-sketchrnn/index.json
+++ b/content/videos/challenges/153-interactive-drawing-with-sketchrnn/index.json
@@ -4,7 +4,7 @@
   "videoNumber": "153",
   "videoId": "ZCXkvwLxBrA",
   "date": "2019-10-31",
-  "languages": ["ml5.js", " p5.js"],
+  "languages": ["ml5.js", "p5.js"],
   "topics": ["sketchRNN", "machine Learning", "Quick, Draw!"],
   "canContribute": true,
   "relatedChallenges": ["128-sketch-rnn-snowflakes", "152-rdp-algorithm"],
@@ -83,12 +83,14 @@
     },
     {
       "title": "Live Stream Archive",
-      "links": [{
-        "icon": "🔴",
-        "title": "Coding Train Live 186",
-        "url": "https://youtu.be/GMaKcRkiNoM?t=4054s",
-        "description": "Live Stream with Interactive Drawing with SketchRNN"
-      }]
+      "links": [
+        {
+          "icon": "🔴",
+          "title": "Coding Train Live 186",
+          "url": "https://youtu.be/GMaKcRkiNoM?t=4054s",
+          "description": "Live Stream with Interactive Drawing with SketchRNN"
+        }
+      ]
     }
   ]
 }

--- a/content/videos/ml5/0-introduction/1-introduction/index.json
+++ b/content/videos/ml5/0-introduction/1-introduction/index.json
@@ -48,7 +48,7 @@
         {
           "icon": "💻",
           "title": "ml5.js",
-          "url": "lhttps://ml5js.org/",
+          "url": "https://ml5js.org/",
           "description": "Reference material for the ml5 library."
         },
         {

--- a/content/videos/ml5/1-classification/1-image-classification/index.json
+++ b/content/videos/ml5/1-classification/1-image-classification/index.json
@@ -4,7 +4,7 @@
   "videoNumber": "1.1",
   "videoId": "yNkAuWz5lnY",
   "date": "2018-08-01",
-  "languages": ["ml5", " p5js", "javascript"],
+  "languages": ["ml5", "p5js", "javascript"],
   "topics": ["machine learning", "image classification", "MobileNet"],
   "canContribute": true,
   "timestamps": [

--- a/content/videos/ml5/2-transfer-learning/1-transfer-learning/index.json
+++ b/content/videos/ml5/2-transfer-learning/1-transfer-learning/index.json
@@ -5,7 +5,7 @@
   "videoId": "kRpZ5OqUY6Y",
   "date": "2018-08-13",
   "languages": ["ml5", "p5js"],
-  "topics": ["image classificaton", "feature extractor"],
+  "topics": ["image classification", "feature extractor"],
   "canContribute": true,
   "timestamps": [
     {

--- a/content/videos/ml5/7-posenet/2-pose-classifier/index.json
+++ b/content/videos/ml5/7-posenet/2-pose-classifier/index.json
@@ -4,7 +4,7 @@
   "videoNumber": "7.2",
   "videoId": "FYgYyq-xqAw",
   "date": "2020-01-15",
-  "languages": ["ml5", "p5jd"],
+  "languages": ["ml5", "p5js"],
   "topics": [
     "pose estimation",
     "data collection",

--- a/content/videos/ml5/8-convolutional-neural-network/2-architecture-of-cnn/index.json
+++ b/content/videos/ml5/8-convolutional-neural-network/2-architecture-of-cnn/index.json
@@ -5,7 +5,7 @@
   "videoId": "qPKsVAI_W6M",
   "date": "2020-02-14",
   "languages": ["ml5", "p5js"],
-  "topics": ["convolutional neutral network", "machine learning"],
+  "topics": ["convolutional neural network", "machine learning"],
   "canContribute": true,
   "timestamps": [
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -169,6 +169,7 @@ module.exports = {
         }
       }
     },
-    `gatsby-plugin-meta-redirect`
+    `gatsby-plugin-meta-redirect`,
+    'gatsby-plugin-netlify'
   ]
 };

--- a/node-scripts/node-generation.js
+++ b/node-scripts/node-generation.js
@@ -139,37 +139,6 @@ exports.createVideoRelatedNode = (
       }
     });
     createNode(newNode);
-
-    for (let tag of newNode.languages) {
-      const content = {
-        id: createNodeId(`--tag/language/${tag}`),
-        parent: node.id,
-        type: 'language',
-        value: tag
-      };
-      createNode({
-        ...content,
-        internal: {
-          type: 'Tag',
-          contentDigest: createContentDigest(content)
-        }
-      });
-    }
-    for (let tag of newNode.topics) {
-      const content = {
-        id: createNodeId(`--tag/topic/${tag}`),
-        parent: node.id,
-        type: 'topic',
-        value: tag
-      };
-      createNode({
-        ...content,
-        internal: {
-          type: 'Tag',
-          contentDigest: createContentDigest(content)
-        }
-      });
-    }
   }
 };
 

--- a/node-scripts/schema.js
+++ b/node-scripts/schema.js
@@ -242,12 +242,6 @@ type CoverImage implements Node {
   file: File! @link
 }
 
-type Tag implements Node {
-  type: String!
-  value: String!
-}
-
-
 type AboutPageInfo implements Node {
   title: String!
   description: String!

--- a/node-scripts/schema.js
+++ b/node-scripts/schema.js
@@ -12,9 +12,7 @@ interface VideoInterface implements Node {
   date: String
   videoNumber: String
   topics: [String!]
-  topicsFlat: String!
   languages: [String!]
-  languagesFlat: String!
   timestamps: [Timestamp!]
   parts: [ChallengePart!]
   codeExamples: [CodeExample!]
@@ -35,9 +33,7 @@ type Video implements VideoInterface & Node {
   date: String
   videoNumber: String
   topics: [String!]
-  topicsFlat: String!
   languages: [String!]
-  languagesFlat: String!
   timestamps: [Timestamp!]
   parts: [ChallengePart!]
   codeExamples: [CodeExample!]
@@ -58,9 +54,7 @@ type Challenge implements VideoInterface & Node {
   date: String
   videoNumber: String
   topics: [String!]
-  topicsFlat: String!
   languages: [String!]
-  languagesFlat: String!
   timestamps: [Timestamp!]
   codeExamples: [CodeExample!]
   parts: [ChallengePart!]
@@ -81,9 +75,7 @@ type GuestTutorial implements VideoInterface & Node {
   date: String
   videoNumber: String
   topics: [String!]
-  topicsFlat: String!
   languages: [String!]
-  languagesFlat: String!
   timestamps: [Timestamp!]
   parts: [ChallengePart!]
   codeExamples: [CodeExample!]
@@ -165,6 +157,10 @@ type Track implements Node {
   cover: CoverImage @link
   numVideos: Int!
   order: Int!
+
+  # as resolvers
+  topics: [String!]
+  languages: [String!]
 }
 
 type Talk implements Node {
@@ -175,9 +171,7 @@ type Talk implements Node {
   link: String
   cover: CoverImage @link
   topics: [String!]
-  topicsFlat: String!
   languages: [String!]
-  languagesFlat: String!
 }
 
 type Guide implements Node {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "gatsby-plugin-image": "^2.16.1",
         "gatsby-plugin-mdx": "^3.16.1",
         "gatsby-plugin-meta-redirect": "^1.1.1",
+        "gatsby-plugin-netlify": "^5.0.1",
         "gatsby-plugin-postcss": "^5.16.0",
         "gatsby-plugin-react-helmet": "^5.16.0",
         "gatsby-plugin-react-svg": "^3.1.0",
@@ -11701,6 +11702,25 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/gatsby-plugin-netlify": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-netlify/-/gatsby-plugin-netlify-5.0.1.tgz",
+      "integrity": "sha512-siy/zX45fIEtfCApH3QkXG0u3mS0y/bf/J2mDMFOrfvhiyB35YDJfaWoRvon+UwJM4dYcMJY17sAnBaBfOQ9GA==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.7",
+        "fs-extra": "^10.0.0",
+        "gatsby-core-utils": "^3.5.2",
+        "kebab-hash": "^0.1.2",
+        "lodash.mergewith": "^4.6.2",
+        "webpack-assets-manifest": "^5.0.6"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^4.0.0"
+      }
+    },
     "node_modules/gatsby-plugin-page-creator": {
       "version": "4.22.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-4.22.0.tgz",
@@ -16400,6 +16420,14 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/kebab-hash": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/kebab-hash/-/kebab-hash-0.1.2.tgz",
+      "integrity": "sha512-BTZpq3xgISmQmAVzkISy4eUutsUA7s4IEFlCwOBJjvSFOwyR7I+fza+tBc/rzYWK/NrmFHjfU1IhO3lu29Ib/w==",
+      "dependencies": {
+        "lodash.kebabcase": "^4.1.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.0.tgz",
@@ -16561,6 +16589,14 @@
       "resolved": "https://registry.npmjs.org/lock/-/lock-1.1.0.tgz",
       "integrity": "sha512-NZQIJJL5Rb9lMJ0Yl1JoVr9GSdo4HTPsUEWsSFzB8dE8DSoiLCVavWZPi7Rnlv/o73u6I24S/XYc/NmG4l8EKA=="
     },
+    "node_modules/lockfile": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+      "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+      "dependencies": {
+        "signal-exit": "^3.0.2"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -16626,6 +16662,21 @@
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ=="
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+    },
+    "node_modules/lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha512-rnYUdIo6xRCJnQmbVFEwcxF144erlD+M3YcJUVesflU9paQaE8p+fJDcIQrlMYbxoANFL+AB9hZrzSBBk5PL+g=="
+    },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g=="
+    },
     "node_modules/lodash.map": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
@@ -16645,6 +16696,11 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "node_modules/lodash.pick": {
       "version": "4.4.0",
@@ -23248,6 +23304,90 @@
         "webpack-cli": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webpack-assets-manifest": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/webpack-assets-manifest/-/webpack-assets-manifest-5.1.0.tgz",
+      "integrity": "sha512-kPuTMEjBrqZQVJ5M6yXNBCEdFbQQn7p+loNXt8NOeDFaAbsNFWqqwR0YL1mfG5LbwhK5FLXWXpuK3GuIIZ46rg==",
+      "dependencies": {
+        "chalk": "^4.0",
+        "deepmerge": "^4.0",
+        "lockfile": "^1.0",
+        "lodash.get": "^4.0",
+        "lodash.has": "^4.0",
+        "schema-utils": "^3.0",
+        "tapable": "^2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5.2.0"
+      }
+    },
+    "node_modules/webpack-assets-manifest/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/webpack-assets-manifest/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/webpack-assets-manifest/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/webpack-assets-manifest/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/webpack-assets-manifest/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/webpack-assets-manifest/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/webpack-dev-middleware": {
@@ -32566,6 +32706,19 @@
         }
       }
     },
+    "gatsby-plugin-netlify": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-netlify/-/gatsby-plugin-netlify-5.0.1.tgz",
+      "integrity": "sha512-siy/zX45fIEtfCApH3QkXG0u3mS0y/bf/J2mDMFOrfvhiyB35YDJfaWoRvon+UwJM4dYcMJY17sAnBaBfOQ9GA==",
+      "requires": {
+        "@babel/runtime": "^7.16.7",
+        "fs-extra": "^10.0.0",
+        "gatsby-core-utils": "^3.5.2",
+        "kebab-hash": "^0.1.2",
+        "lodash.mergewith": "^4.6.2",
+        "webpack-assets-manifest": "^5.0.6"
+      }
+    },
     "gatsby-plugin-page-creator": {
       "version": "4.22.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-4.22.0.tgz",
@@ -35917,6 +36070,14 @@
         "object.assign": "^4.1.3"
       }
     },
+    "kebab-hash": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/kebab-hash/-/kebab-hash-0.1.2.tgz",
+      "integrity": "sha512-BTZpq3xgISmQmAVzkISy4eUutsUA7s4IEFlCwOBJjvSFOwyR7I+fza+tBc/rzYWK/NrmFHjfU1IhO3lu29Ib/w==",
+      "requires": {
+        "lodash.kebabcase": "^4.1.1"
+      }
+    },
     "keyv": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.0.tgz",
@@ -36044,6 +36205,14 @@
       "resolved": "https://registry.npmjs.org/lock/-/lock-1.1.0.tgz",
       "integrity": "sha512-NZQIJJL5Rb9lMJ0Yl1JoVr9GSdo4HTPsUEWsSFzB8dE8DSoiLCVavWZPi7Rnlv/o73u6I24S/XYc/NmG4l8EKA=="
     },
+    "lockfile": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+      "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+      "requires": {
+        "signal-exit": "^3.0.2"
+      }
+    },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -36109,6 +36278,21 @@
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ=="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+    },
+    "lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha512-rnYUdIo6xRCJnQmbVFEwcxF144erlD+M3YcJUVesflU9paQaE8p+fJDcIQrlMYbxoANFL+AB9hZrzSBBk5PL+g=="
+    },
+    "lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g=="
+    },
     "lodash.map": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
@@ -36128,6 +36312,11 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "lodash.pick": {
       "version": "4.4.0",
@@ -41083,6 +41272,65 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
           "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w=="
+        }
+      }
+    },
+    "webpack-assets-manifest": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/webpack-assets-manifest/-/webpack-assets-manifest-5.1.0.tgz",
+      "integrity": "sha512-kPuTMEjBrqZQVJ5M6yXNBCEdFbQQn7p+loNXt8NOeDFaAbsNFWqqwR0YL1mfG5LbwhK5FLXWXpuK3GuIIZ46rg==",
+      "requires": {
+        "chalk": "^4.0",
+        "deepmerge": "^4.0",
+        "lockfile": "^1.0",
+        "lodash.get": "^4.0",
+        "lodash.has": "^4.0",
+        "schema-utils": "^3.0",
+        "tapable": "^2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gatsby-plugin-image": "^2.16.1",
     "gatsby-plugin-mdx": "^3.16.1",
     "gatsby-plugin-meta-redirect": "^1.1.1",
+    "gatsby-plugin-netlify": "^5.0.1",
     "gatsby-plugin-postcss": "^5.16.0",
     "gatsby-plugin-react-helmet": "^5.16.0",
     "gatsby-plugin-react-svg": "^3.1.0",

--- a/src/components/ItemsPage.js
+++ b/src/components/ItemsPage.js
@@ -31,19 +31,29 @@ const ItemsPage = ({
   SeparatorCharacter,
   EndPageCharacter,
   characterOrientation,
-  languages,
-  topics,
   midSection,
   children,
   showPagination,
   previousPagePath,
   humanPageNumber,
   numberOfPages,
-  nextPagePath
+  nextPagePath,
+  filtersFilePath
 }) => {
   const [expanded, setExpanded] = useState(false);
+  const [languages, setLanguages] = useState([selectedLanguage]);
+  const [topics, setTopics] = useState([selectedTopic]);
   const filtersRef = useRef();
   const shouldScroll = location.pathname.split('/').length > 2;
+
+  useEffect(() => {
+    (async () => {
+      const resp = await fetch(filtersFilePath);
+      const doc = await resp.json();
+      setLanguages(doc.languages);
+      setTopics(doc.topics);
+    })();
+  }, [filtersFilePath]);
 
   useEffect(() => {
     if (location?.state?.expanded !== undefined)

--- a/src/templates/challenges.js
+++ b/src/templates/challenges.js
@@ -1,14 +1,14 @@
-import React, { Fragment } from 'react';
 import { graphql, Link } from 'gatsby';
+import React, { Fragment } from 'react';
 
-import ItemsPage from '../components/ItemsPage';
-import Image from '../components/Image';
 import Card from '../components/challenges/Card';
+import Image from '../components/Image';
+import ItemsPage from '../components/ItemsPage';
 
-import PlayButton from '../images/playbutton.svg';
-import BracketsCharacter from '../images/characters/SquareBrackets_4.mini.svg';
-import BracketsCharacter2 from '../images/characters/SquareBrackets_2.mini.svg';
 import RainbowCharacter from '../images/characters/Rainbow_1.mini.svg';
+import BracketsCharacter2 from '../images/characters/SquareBrackets_2.mini.svg';
+import BracketsCharacter from '../images/characters/SquareBrackets_4.mini.svg';
+import PlayButton from '../images/playbutton.svg';
 
 import { getReadableDate } from '../hooks';
 
@@ -19,8 +19,6 @@ const ChallengesPage = ({ data, pageContext, location }) => {
   const pageData = data.pageData.nodes[0];
   const challenges = data.challenges.nodes;
   const recentChallenge = data.recentChallenge.nodes[0];
-  const languages = data.languages.nodes.map(({ value }) => value);
-  const topics = data.topics.nodes.map(({ value }) => value);
 
   const challengesPlaceholder = data.challengePlaceholderImage
     ? data.challengePlaceholderImage.childImageSharp.gatsbyImageData
@@ -40,8 +38,6 @@ const ChallengesPage = ({ data, pageContext, location }) => {
       SeparatorCharacter={BracketsCharacter2}
       EndPageCharacter={RainbowCharacter}
       characterOrientation="left"
-      languages={languages}
-      topics={topics}
       midSection={
         <RecentChallenge
           featuredChallengeTitle={pageData.featuredText}
@@ -53,7 +49,8 @@ const ChallengesPage = ({ data, pageContext, location }) => {
       previousPagePath={pageContext.previousPagePath}
       numberOfPages={pageContext.numberOfPages}
       nextPagePath={pageContext.nextPagePath}
-      humanPageNumber={pageContext.humanPageNumber}>
+      humanPageNumber={pageContext.humanPageNumber}
+      filtersFilePath="/filters-challenges.json">
       {() =>
         challenges.length > 0 && (
           <div className={css.challenges}>
@@ -126,7 +123,7 @@ const RecentChallenge = ({
 };
 
 export const query = graphql`
-  query(
+  query (
     $skip: Int!
     $limit: Int!
     $topicRegex: String!
@@ -155,8 +152,8 @@ export const query = graphql`
     }
     challenges: allChallenge(
       filter: {
-        languagesFlat: { regex: $languageRegex }
-        topicsFlat: { regex: $topicRegex }
+        languages: { regex: $languageRegex }
+        topics: { regex: $topicRegex }
       }
       sort: { order: DESC, fields: date }
       skip: $skip
@@ -193,16 +190,6 @@ export const query = graphql`
             }
           }
         }
-      }
-    }
-    languages: allTag(filter: { type: { eq: "language" } }) {
-      nodes {
-        value
-      }
-    }
-    topics: allTag(filter: { type: { eq: "topic" } }) {
-      nodes {
-        value
       }
     }
     challengePlaceholderImage: file(

--- a/src/templates/tracks.js
+++ b/src/templates/tracks.js
@@ -1,13 +1,13 @@
-import React, { Fragment } from 'react';
 import { graphql } from 'gatsby';
+import React, { Fragment } from 'react';
 
 import ItemsPage from '../components/ItemsPage';
 import Spacer from '../components/Spacer';
 import TrackCard from '../components/tracks/Card';
 
-import SquareCharacter from '../images/characters/Square_4.mini.svg';
-import SquareCharacter2 from '../images/characters/Square_3.mini.svg';
 import AsteriskCharacter from '../images/characters/Asterik_5.mini.svg';
+import SquareCharacter2 from '../images/characters/Square_3.mini.svg';
+import SquareCharacter from '../images/characters/Square_4.mini.svg';
 
 // import * as css from './tracks.module.css';
 
@@ -15,8 +15,6 @@ const TracksPage = ({ data, pageContext, location }) => {
   const { language, topic } = pageContext;
   const pageData = data.pageData.nodes[0];
   const tracks = data.tracks.nodes;
-  const languages = data.languages.nodes.map(({ value }) => value);
-  const topics = data.topics.nodes.map(({ value }) => value);
 
   const placeholderMainTrackImage =
     data.placeholderMainTrackImage.childImageSharp.gatsbyImageData;
@@ -37,13 +35,12 @@ const TracksPage = ({ data, pageContext, location }) => {
       SeparatorCharacter={SquareCharacter2}
       EndPageCharacter={AsteriskCharacter}
       characterOrientation="center"
-      languages={languages}
-      topics={topics}
       showPagination={tracks.length > 0}
       previousPagePath={pageContext.previousPagePath}
       numberOfPages={pageContext.numberOfPages}
       nextPagePath={pageContext.nextPagePath}
-      humanPageNumber={pageContext.humanPageNumber}>
+      humanPageNumber={pageContext.humanPageNumber}
+      filtersFilePath="/filters-tracks.json">
       {(filters) =>
         tracks.map((track) => (
           <Fragment key={track.slug}>
@@ -82,8 +79,8 @@ export const query = graphql`
     }
     tracks: allTrack(
       filter: {
-        languagesFlat: { regex: $languageRegex }
-        topicsFlat: { regex: $topicRegex }
+        languages: { regex: $languageRegex }
+        topics: { regex: $topicRegex }
       }
       sort: { order: ASC, fields: order }
       skip: $skip
@@ -137,16 +134,6 @@ export const query = graphql`
     ) {
       childImageSharp {
         gatsbyImageData
-      }
-    }
-    languages: allTag(filter: { type: { eq: "language" } }) {
-      nodes {
-        value
-      }
-    }
-    topics: allTag(filter: { type: { eq: "topic" } }) {
-      nodes {
-        value
       }
     }
   }


### PR DESCRIPTION
Hi @shiffman & team!

I was watching the [stream on YouTube](https://youtu.be/EzYDNydDUfc?t=2391) last Friday and was intrigued by the Gatsby/GraphQL/Netlify log warnings and slow builds. Thought it would be a fun challenge to learn a bit more about these and see if I could help out.

The slowness comes from building the tracks and challenges pages with all filter permutations and pagination. It ends up being a lot of pages!

Here's what I did:

- **Make some of the async code run serially**. There are just too many things running at once, and it ends up making performance worst. This was enough to get rid of the flood of warnings in the logs.
- **Rewrote some GraphQL queries** to make them a bit faster
- **Build contextual languages and topics lists to reduce total permutations and improve UX**. While the challenges and tracks share some topics and languages, there's a lot that doesn't overlap here. This means lots of useless result pages were being generated, and dropdown filters had a lot of options that would return no matches. This appears to have cut the amount of generated pages by more than half.
- **Re-architect how tracks and challenges filters are populated**. We are now generating two static JSON files that are fetched at runtime, which has a lot of positive repercussions:
  - less work for `createPages` process
  - smaller `page-data.json` for every page with filters, and the extracted data found in those new JSON files can be cached by the browser during a user session
  - if there is a topic or language content change, I think that only the relevant pages would get rebuilt instead of every single page that has a filter dropdown component

Some stats on my M1 MacBook Air:

|| total pages built | `createPages` execution |
| --- | ---: | ---: |
|baseline| 19,911 | 51 seconds |
|with this PR| 7,213 | 9 seconds |

**Bonus!**
- Added the `gatsby-plugin-netlify` plugin dependency. It seems to log slow queries during build, so potentially some good information to optimize things further.
- Fixed a few typos in the content, mostly to observe the Netlify build behavior
- Fixed a caching issue. Changes to topics and languages inside track videos and chapters did not bubble up correctly to the parent track level until the Gatsby cache expired or was explicitly purged. This was fixed by using GraphQL resolvers. It should improve the cache deployment issues mentioned in https://github.com/CodingTrain/thecodingtrain.com/pull/786#issuecomment-1322058585

Lastly, I noticed that the Gatsby Netlify plugin is out of date. Maybe that can further help with build speed and caching? I think it's called `Essential Gatsby` in the dashboard. It needs to be uninstalled and re-installed to upgrade https://app.netlify.com/plugins

<img width="1002" alt="Screenshot 2022-11-19 at 1 36 52 PM" src="https://user-images.githubusercontent.com/4009209/202866363-f9e0a513-37fd-488e-a700-3508b108d5dc.png">

Hope that all made sense and I didn't break anything in the process!

Let me know if I can help with something else. Perhaps wrapping up #489 since it would also help reduce the overall amount of built pages by removing duplicated topics and languages?