### PR TITLE
Revert #805 (showcase PR preview URL)

### DIFF
--- a/netlify/functions/submission-background.js
+++ b/netlify/functions/submission-background.js
@@ -152,9 +152,4 @@ exports.handler = async function (event) {
   );
 
   console.log('Done!');
-
-  return {
-    statusCode: 200,
-    body: JSON.stringify({ success: true, pullRequestNo: prRes.data.number  }),
-  };
 };

--- a/src/components/PassengerShowcaseForm.js
+++ b/src/components/PassengerShowcaseForm.js
@@ -44,7 +44,6 @@ const PassengerShowcaseForm = () => {
   const [state, setState] = useState(defaultState);
   const [error, setError] = useState(null);
   const [submitted, setSubmitted] = useState(false);
-  const [githubPRNo, setGithubPRNo] = useState(null);
 
   const data = useStaticQuery(graphql`
     query {
@@ -267,14 +266,8 @@ const PassengerShowcaseForm = () => {
         {error && <div className={css.error}>{error}</div>}
         {submitted && (
           <div className={css.submitted}>
-            Thank you for submitting to the Passenger Showcase!{' '}
-            {githubPRNo && (
-              <a
-                href={`https://github.com/CodingTrain/thecodingtrain.com/pull/${githubPRNo}`}>
-                You can follow this linked pull request on GitHub for more.
-              </a>
-            )}{' '}
-            Please refresh the page in order to upload another submission.
+            Thank you for submitting to the Passenger Showcase! Please refresh
+            the page in order to upload another submission.
           </div>
         )}
         <Button


### PR DESCRIPTION
This PR reverts all changes in #805.

In #805, the github PR link was added on showcase submission, which allowed the contributor to go to the respective pull request for their showcase. However, it introduced an error due to which an error message was displayed upon submission, even though the showcase was being submitted and the pull request was being created. (initially found by @kfahn22)

I created and merged #822, where I removed the code which caused the bug to temporarily fix the issue.

As it turns out, the problem is that the showcase submission script is a Netlify Background function, and it is not possible to return any data from a background function to the client, thus preventing the client to receive the github PR number, which was being used to display its link to the contributor. 

So, it is not possible to link the contributor to their pull request, because the submission script is asynchronous in nature.

* [Background Function](https://docs.netlify.com/functions/background-functions/) docs on Netlify

----
PS: I found that the [`netlify` CLI](https://www.netlify.com/products/cli/) can be used to debug netlify functions locally, instead of creating creating new PRs every time. 