### PR TITLE
Stabilize HTML build outputs

### DIFF
--- a/src/components/ItemsPage.js
+++ b/src/components/ItemsPage.js
@@ -129,6 +129,7 @@ const ItemsPage = ({
           selected={selectedLanguage}
           onChange={setSelectedLanguage}
           variant={variant}
+          instanceId="languages-filter"
         />
 
         <Select
@@ -140,6 +141,7 @@ const ItemsPage = ({
           selected={selectedTopic}
           onChange={setSelectedTopic}
           variant={variant}
+          instanceId="topics-filter"
         />
       </div>
 

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -14,7 +14,8 @@ export const Select = ({
   onChange,
   icon,
   className,
-  variant
+  variant,
+  instanceId
 }) => {
   const opts = useMemo(() => options.map(toOption), [options]);
   const handleOnChange = (o, action) => onChange(o ? o.value : o);
@@ -38,6 +39,7 @@ export const Select = ({
             options={opts}
             defaultValue={selected ? toOption(selected) : selected}
             onChange={handleOnChange}
+            instanceId={instanceId}
           />
 
           <div className={css.itemSpacer}></div>

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'gatsby';
 
 import Menu from './Menu';
@@ -39,7 +39,18 @@ const longDate = (date) => {
 };
 
 const TopBar = () => {
-  const today = new Date();
+  const [date, setDate] = useState({ long: '', short: '' });
+
+  useEffect(() => {
+    // Runs client-side only, the date should not be captured at build time during SSG
+
+    const today = new Date();
+    setDate({
+      long: longDate(today),
+      short: shortDate(today)
+    });
+  }, []);
+
   return (
     <div className={css.outer}>
       <header className={css.root}>
@@ -50,8 +61,8 @@ const TopBar = () => {
         </div>
         <div className={css.clock}>🕛</div>
         <div className={css.date}>
-          <span className={css.longDate}>{longDate(today)}</span>
-          <span className={css.shortDate}>{shortDate(today)}</span>
+          <span className={css.longDate}>{date.long}</span>
+          <span className={css.shortDate}>{date.short}</span>
         </div>
         <Menu />
       </header>


### PR DESCRIPTION
Some additional improvements to build/deploy performance.

It's been bothering me that the Netlify build often needs to redeploy thousands of files for no apparent reason after merging PRs that often don't change much. I've been diffing build outputs to understand why.

- the `react-select` component library increments element ids internally by default. This is causing a problem because Gatsby builds using parallel worker threads that execute in an unpredictable order, so a page will very likely end up with a different select component id between each build. Explicitly setting the `instanceId` prop fixes the problem.
https://github.com/JedWatson/react-select/blob/c350a124f8de853a79e0158578d438a35e67e63e/packages/react-select/src/Select.tsx#L638-L639

- the `TopBar` component that displays today's date is captured in HTML during the build phase. It creates some visual flickering because the date in the markup is often not the same as after hydration. It also forces every HTML page to be redeployed on a new build if the last build didn't happen on the same date (UTC). This PR only displays the date after React hydration to address the problem.

https://user-images.githubusercontent.com/4009209/206729522-5045becd-e87a-4277-a93e-ba62c40c0cb0.mp4

<img width="1171" alt="Screenshot 2022-12-09 at 9 44 41 AM" src="https://user-images.githubusercontent.com/4009209/206727461-bb4ed8cc-0a2b-4e67-813d-774772d410ad.png">

- Migrating to Gatsby 5(#818) seem to have helped a bit too, but there's one remaining issue I've been tracking down where the only thing changing between a clean build and the following incremental build is the `webpackCompilationHash` value. See https://github.com/gatsbyjs/gatsby/issues/33450. The fix was a breaking change for Gatsby 4 and was supposed to be rolled out in v5 - but I think it might've slipped. Not much we can do about this for now.