### PR TITLE
Skip Netlify Preview Build for changes to README + .allcontributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ This will start a local server and the website will now be accessible on [localh
 **Note:** In some cases, specially when updating loaded content, you need to restart the local server with `npm run dev`.
 And in some cases that may fail because of Gatsby's cache usage. If you run `npm run clean` before `npm run dev`, that should fix it.
 
-Please note that changes to the README.md file will not trigger a Netlify build.
-
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This will start a local server and the website will now be accessible on [localh
 **Note:** In some cases, specially when updating loaded content, you need to restart the local server with `npm run dev`.
 And in some cases that may fail because of Gatsby's cache usage. If you run `npm run clean` before `npm run dev`, that should fix it.
 
+Please note that changes to the README.md file will not trigger a Netlify build.
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
   command = "npm run build-ci"
-  ignore = "git diff --quiet HEAD^ HEAD -- README.md .all-contributorsrc"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF-- README.md .all-contributorsrc"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
   command = "npm run build-ci"
   # skip build when changes are isolated to README.md or .all-contributorsrc
-  ignore = "git diff HEAD^ HEAD ':(exclude)README.md' ':(exclude).all-contributorsrc' "
+  ignore = "git diff --quiet HEAD^ HEAD ':(exclude)README.md' ':(exclude).all-contributorsrc' "

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,4 @@
 [build]
   command = "npm run build-ci"
+  # skip build when changes are isolated to README.md or .all-contributorsrc
   ignore = "git diff --quiet HEAD^ HEAD -- README.md -- .all-contributorsrc"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
   command = "npm run build-ci"
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF-- README.md .all-contributorsrc"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- README.md .all-contributorsrc"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,3 @@
 [build]
   command = "npm run build-ci"
+  ignore = "git diff --quiet HEAD^ HEAD -- README.md .all-contributorsrc"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
   command = "npm run build-ci"
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- README.md .all-contributorsrc"
+  ignore = "git --quiet diff HEAD^ HEAD -- README.md -- .all-contributorsrc"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
   command = "npm run build-ci"
-  ignore = "git --quiet diff HEAD^ HEAD -- README.md -- .all-contributorsrc"
+  ignore = "git diff --quiet HEAD^ HEAD -- README.md -- .all-contributorsrc"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
   command = "npm run build-ci"
   # skip build when changes are isolated to README.md or .all-contributorsrc
-  ignore = "git diff --quiet HEAD^ HEAD -- README.md -- .all-contributorsrc"
+  ignore = "git diff HEAD^ HEAD ':(exclude)README.md' ':(exclude).all-contributorsrc' "


### PR DESCRIPTION
This PR updates netlify.toml for Netlify's build CI to ignore file changes to allcontributors and README.


**Testing**

Locally I tested this by running `"git diff --quiet HEAD^ HEAD ':(exclude)README.md' ':(exclude).all-contributorsrc' "`  with and without changes to the relevant files and confirming that it returned a diff when those files changed.  I also pushed multiple commits to this remote branch and looked at the deploy logs to determine whether or not Netlify successfully built or cancelled the build based on the files that were part of the diff for the latest commit.
 
Netlify build detects the ignore command and continued building this PR when there were changes to `netlify.toml` 
<img width="1105" alt="Screen Shot 2022-12-15 at 10 32 20 PM" src="https://user-images.githubusercontent.com/6998954/208015902-4f1ef7cf-4d66-4232-b3c4-5c11f8b44927.png">

Netlify cancelled build when the only changes in the PR were to`README.md` 
<img width="1135" alt="Screen Shot 2022-12-15 at 10 35 38 PM" src="https://user-images.githubusercontent.com/6998954/208016422-a1ab369b-1590-4b6c-9306-d74b65891bb7.png">


Note: The last build is showing up as cancelled because the commit removed the file changes to `README.md` (which built will now ignore) and there were no other file changes outside of `README.md.


**Outstanding Questions**
Should I look into only triggering this change for deploy previews with something like `[context.deploy-preview]` or should this apply to all builds and not just deploy previews? I am assuming it should apply to all builds but the issue was specifically framed at deploy previews.


**Related Links:**
https://github.com/CodingTrain/thecodingtrain.com/issues/530
https://www.netlify.com/blog/2020/04/27/ignore-unnecessary-builds-to-optimize-your-build-times/
