### PR TITLE
Fix Gatsby build cache not detecting new showcases

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -296,9 +296,15 @@ const filterByTagsResolver = async (
 };
 
 const showcaseResolver = async (source, args, context, info) => {
+  const query = {};
+
+  set(query, 'filter.video.id.eq', source.id);
+  set(query, 'sort.order', ['ASC']);
+  set(query, 'sort.fields', ['name']);
+
   const { entries } = await context.nodeModel.findAll({
     type: 'Contribution',
-    query: { filter: { video: { id: { eq: source.id } } } }
+    query
   });
 
   return entries;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -295,6 +295,15 @@ const filterByTagsResolver = async (
   return entries;
 };
 
+const showcaseResolver = async (source, args, context, info) => {
+  const { entries } = await context.nodeModel.findAll({
+    type: 'Contribution',
+    query: { filter: { video: { id: { eq: source.id } } } }
+  });
+
+  return entries;
+};
+
 exports.createResolvers = ({ createResolvers }) => {
   const resolvers = {
     Track: {
@@ -307,6 +316,18 @@ exports.createResolvers = ({ createResolvers }) => {
         type: ['String'],
         resolve: async (source, args, context, info) =>
           await tagResolver(source, context, 'languages')
+      }
+    },
+    Challenge: {
+      showcase: {
+        type: ['Contribution'],
+        resolve: showcaseResolver
+      }
+    },
+    Video: {
+      showcase: {
+        type: ['Contribution'],
+        resolve: showcaseResolver
       }
     },
     Query: {

--- a/node-scripts/node-generation.js
+++ b/node-scripts/node-generation.js
@@ -87,17 +87,7 @@ exports.createVideoRelatedNode = (
   } else {
     const slug = parent.relativeDirectory;
     const data = getJson(node);
-    // If folder present, it reads every contribution file present in the
-    // video folder so that we can get the corresponding ID's to link them
-    const showcase = fs.existsSync(`${parent.dir}/showcase`)
-      ? fs
-          .readdirSync(`${parent.dir}/showcase`)
-          .filter((file) => file.includes('.json'))
-          .map(
-            (file) =>
-              `${slugPrefix}${parent.relativeDirectory}/showcase/${file}`
-          )
-      : [];
+
     const timestamps = timestampsWithSeconds(data.timestamps ?? []);
     const parts = (data.parts ?? []).map((part) => ({
       ...part,
@@ -123,7 +113,6 @@ exports.createVideoRelatedNode = (
       })),
       groupLinks: data.groupLinks ?? [],
       canContribute: data.canContribute ?? schemaType === 'Challenge',
-      showcase: showcase.map((file) => createNodeId(file)),
       relatedChallenges: (data.relatedChallenges ?? []).map((slug) =>
         createNodeId(
           `--videos/${

--- a/node-scripts/schema.js
+++ b/node-scripts/schema.js
@@ -17,11 +17,13 @@ interface VideoInterface implements Node {
   parts: [ChallengePart!]
   codeExamples: [CodeExample!]
   canContribute: Boolean!
-  showcase: [Contribution!] @link
   relatedChallenges: [Challenge!] @link
   cover: CoverImage @link
   groupLinks: [GroupLink!]
   source: String!
+
+  # as resolver
+  showcase: [Contribution]
 }
 
 type Video implements VideoInterface & Node {
@@ -38,11 +40,13 @@ type Video implements VideoInterface & Node {
   parts: [ChallengePart!]
   codeExamples: [CodeExample!]
   canContribute: Boolean!
-  showcase: [Contribution!] @link
   relatedChallenges: [Challenge!] @link
   cover: CoverImage @link
   groupLinks: [GroupLink!]
   source: String!
+
+  # as resolver
+  showcase: [Contribution]
 }
 
 type Challenge implements VideoInterface & Node {
@@ -59,11 +63,13 @@ type Challenge implements VideoInterface & Node {
   codeExamples: [CodeExample!]
   parts: [ChallengePart!]
   canContribute: Boolean!
-  showcase: [Contribution!] @link
   relatedChallenges: [Challenge!] @link
   cover: CoverImage @link
   groupLinks: [GroupLink!]
   source: String!
+
+  # as resolver
+  showcase: [Contribution]
 }
 
 type GuestTutorial implements VideoInterface & Node {


### PR DESCRIPTION
Because of the way the Gatsby nodes were modeled, adding a new showcase would not be detected by the build until the parent challenge or track video JSON would be modified.

You can clearly see the problem in yesterday's showcase PR #841
The incremental build did not detect any changes and the contributor's content is not in the preview link - nor is it right now in production after merge: https://app.netlify.com/sites/codingtrain/deploys/63a010ca0cc5690009e46d9e