### PR TITLE
`TopBar` and `Footer` component to Gatsby slices

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -19,6 +19,7 @@ const {
   createAboutPageCoverImageNode
 } = require('./node-scripts/node-generation');
 const {
+  createSlices,
   createTrackVideoPages,
   createTracksPages,
   createChallengesPages,
@@ -225,7 +226,9 @@ exports.onCreateNode = ({
 };
 
 exports.createPages = async function ({ actions, graphql }) {
-  const { createPage } = actions;
+  const { createPage, createSlice } = actions;
+
+  await createSlices(createSlice);
   await createTrackVideoPages(graphql, createPage);
   await createTracksPages(graphql, createPage);
   await createChallengesPages(graphql, createPage);

--- a/node-scripts/page-generation.js
+++ b/node-scripts/page-generation.js
@@ -16,6 +16,22 @@ const extractTags = (nodes, pluckKey) => {
 };
 
 /**
+ * Creates Gatsby slices
+ * @param {function} createSlice - Gatsby's createSlice function
+ */
+exports.createSlices = async (createSlice) => {
+  createSlice({
+    id: `TopBar`,
+    component: require.resolve(`../src/components/TopBar.js`)
+  });
+
+  createSlice({
+    id: `Footer`,
+    component: require.resolve(`../src/components/Footer.js`)
+  });
+};
+
+/**
  * Creates single Challenge pages for all loaded Challenge nodes
  * @param {function} graphql - Gatsby's graphql function
  * @param {function} createPage - Gatsby's createPage function

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,8 +1,10 @@
 import React from 'react';
+import { Slice } from 'gatsby';
 
 import Head from './Head';
-import TopBar from './TopBar';
-import Footer from './Footer';
+
+// fixes chunks order warnings
+import '../styles/styles.module.css';
 
 import '../styles/base.css';
 import '../styles/variables.css';
@@ -15,9 +17,9 @@ const Layout = ({ children, title, description, image }) => {
     <div className={css.container}>
       <Head title={title} description={description} image={image} />
       <div className={css.content}>
-        <TopBar />
+        <Slice alias="TopBar" />
         {children}
-        <Footer />
+        <Slice alias="Footer" />
       </div>
     </div>
   );


### PR DESCRIPTION
I converted the `TopBar` and `Footer` component to use [Gatsby 5 slices](https://www.gatsbyjs.com/docs/how-to/performance/using-slices/). I'm not convinced we'll see a significant impact to build times here because that's not where the heavy lifting happens, but it can't hurt.

Eventually we could find other opportunities to use slices that could move the needle a bit more. For example, I was thinking the top part of the challenges page could be a good one to isolate and put in a slice because it's the same for at least 6k pages. And each content card will also appear in a lot of pages because of the filters and pagination, they can each be their own slice.

<img width="1653" alt="image" src="https://user-images.githubusercontent.com/4009209/208694671-9678a828-aeb7-4026-9560-ad690a748e19.png">
