### PR TITLE
Fix character encoding for two showcase contributor names

### DIFF
--- a/content/videos/challenges/154-tic-tac-toe-minimax/showcase/contribution-1669289438.json
+++ b/content/videos/challenges/154-tic-tac-toe-minimax/showcase/contribution-1669289438.json
@@ -1,7 +1,7 @@
 {
   "title": "Checkers game with minimax AI, alpha-beta pruning, transposition tables, quescience search",
   "author": {
-    "name": "Marius Köppen"
+    "name": "Marius KÃ¶ppen"
   },
   "url": "https://mariuskoeppen.github.io/Checkers/",
   "submittedOn": "2022-11-24"

--- a/content/videos/challenges/67-pong/showcase/contribution-1665085801.json
+++ b/content/videos/challenges/67-pong/showcase/contribution-1665085801.json
@@ -1,7 +1,7 @@
 {
   "title": "wrecking ball (didnt find bouncing ball challenge, neither the dvd one...)",
   "author": {
-    "name": "Josie Victória",
+    "name": "Josie VictÃ³ria",
     "url": "https://github.com/MiauToofu"
   },
   "url": "https://editor.p5js.org/MiauToofu/sketches/BUqON__2U",


### PR DESCRIPTION
There was something wrong with the character encoding in these JSON files.

<img width="503" alt="Screenshot 2022-12-20 at 10 31 48 AM" src="https://user-images.githubusercontent.com/4009209/208704395-08e67629-e04f-420d-91d8-ac8a96cc5d67.png">

<img width="449" alt="Screenshot 2022-12-20 at 10 32 43 AM" src="https://user-images.githubusercontent.com/4009209/208704575-e4bdafe8-3eac-44f7-a535-f82baf8e915f.png">
