### PR TITLE
Fix video dates

### DIFF
--- a/content-testing/file-formats.js
+++ b/content-testing/file-formats.js
@@ -8,7 +8,10 @@ const video = {
       videoNumber: { type: 'string' },
       videoId: { isRequired: true, type: 'string' },
       nebulaSlug: { isRequired: false, type: 'string' },
-      date: { type: 'string' },
+      date: {
+        isRequired: true,
+        type: 'string'
+      },
       languages: { type: 'array', content: { type: 'string' } },
       topics: { type: 'array', content: { type: 'string' } },
       canContribute: { type: 'boolean' },

--- a/content/videos/challenges/15-object-oriented-fractal-trees/index.json
+++ b/content/videos/challenges/15-object-oriented-fractal-trees/index.json
@@ -3,7 +3,7 @@
   "description": "More algorithmic botany! Another way to generate a fractal tree is to consider every part of the tree an object, so that we can apply forces and attributes to all the branches and leaves and more!",
   "videoNumber": "15",
   "videoId": "fcdNSZ9IzJM",
-  "date": "2016-06-02",
+  "date": "2016-05-30",
   "languages": ["p5.js", "JavaScript"],
   "topics": [
     "fractals",
@@ -18,22 +18,13 @@
     "174-graphics-applesoft-basic"
   ],
   "timestamps": [
-    {
-      "time": "0:00",
-      "title": "Introducing today's topic"
-    },
-    {
-      "time": "1;44",
-      "title": "Write a Branch constructor function"
-    },
+    { "time": "0:00", "title": "Introducing today's topic" },
+    { "time": "1;44", "title": "Write a Branch constructor function" },
     {
       "time": "3:00",
       "title": "Add a single Branch object for the root of the tree"
     },
-    {
-      "time": "5:53",
-      "title": "Add a tree array"
-    },
+    { "time": "5:53", "title": "Add a tree array" },
     {
       "time": "7:20",
       "title": "Write a branch object to created 2 attached branch objects"
@@ -42,50 +33,20 @@
       "time": "9:30",
       "title": "Create a direction vector that points from the beginning to the end of the vector"
     },
-    {
-      "time": "10:12",
-      "title": "Determine new end point"
-    },
-    {
-      "time": "11:00",
-      "title": "Add a new branch to the right"
-    },
-    {
-      "time": "12:00",
-      "title": "Add a new branch to the left"
-    },
-    {
-      "time": "13:00",
-      "title": "Shrink the branches"
-    },
+    { "time": "10:12", "title": "Determine new end point" },
+    { "time": "11:00", "title": "Add a new branch to the right" },
+    { "time": "12:00", "title": "Add a new branch to the left" },
+    { "time": "13:00", "title": "Shrink the branches" },
     {
       "time": "14:39",
       "title": "Push new branches to the tree when the mouse is pressed"
     },
-    {
-      "time": "15:37",
-      "title": "Loop through the array backwards"
-    },
-    {
-      "time": "16:12",
-      "title": "Deal with duplicate branches"
-    },
-    {
-      "time": "17:31",
-      "title": "Add a jitter function"
-    },
-    {
-      "time": "19:52",
-      "title": "Add leaves at the end of the branches"
-    },
-    {
-      "time": "21:58",
-      "title": "Have the leaves fall"
-    },
-    {
-      "time": "22:45",
-      "title": "Thanks for watching!"
-    }
+    { "time": "15:37", "title": "Loop through the array backwards" },
+    { "time": "16:12", "title": "Deal with duplicate branches" },
+    { "time": "17:31", "title": "Add a jitter function" },
+    { "time": "19:52", "title": "Add leaves at the end of the branches" },
+    { "time": "21:58", "title": "Have the leaves fall" },
+    { "time": "22:45", "title": "Thanks for watching!" }
   ],
   "codeExamples": [
     {
@@ -135,13 +96,7 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/challenges/159-simple-pendulum/index.json
+++ b/content/videos/challenges/159-simple-pendulum/index.json
@@ -3,7 +3,7 @@
   "description": "Choo choo! In this challenge, I build on chapter 3 (Oscillating Motion) of the Nature of Code series and simulate a simple pendulum in p5.js via angular acceleration.",
   "videoNumber": "159",
   "videoId": "NBWMtlbbOag",
-  "date": "2021-02-16",
+  "date": "2021-02-20",
   "languages": ["JavaScript", "p5.js"],
   "relatedChallenges": ["93-double-pendulum", "160-spring-forces"],
   "topics": [
@@ -69,17 +69,13 @@
       "title": "Pendulum OOP",
       "description": "Simulation of a pendulum using OOP",
       "image": "oop.png",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/lJz1cmMp4"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/lJz1cmMp4" }
     },
     {
       "title": "Array of Pendulums",
       "description": "Simulating multiple pendulums",
       "image": "array.png",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/Bj82tUlIO"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/Bj82tUlIO" }
     }
   ],
   "groupLinks": [
@@ -137,13 +133,7 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/challenges/165-slide-puzzle/index.json
+++ b/content/videos/challenges/165-slide-puzzle/index.json
@@ -3,60 +3,27 @@
   "description": "Let's make a slide puzzle in p5.js together! We'll be using images, nested loops, and arrays, and by the end of our journey, we'll have a fully playable game!",
   "videoNumber": "165",
   "videoId": "uQZLzhrzEs4",
-  "date": "2022-01-31",
+  "date": "2022-02-01",
   "languages": ["JavaScript", "p5.js"],
   "topics": ["pixels", "arrays", "game"],
   "canContribute": true,
   "relatedChallenges": ["94-2048", "142-rubiks-cube", "149-tic-tac-toe"],
   "timestamps": [
     { "title": "Welcome!", "time": "0:00" },
-    {
-      "title": "What is copy()?",
-      "time": "2:24"
-    },
+    { "title": "What is copy()?", "time": "2:24" },
     { "title": "The Tile class", "time": "3:24" },
-    {
-      "title": "Copying tiles from the source image.",
-      "time": "4:40"
-    },
-    {
-      "title": "Creating an Array for the board.",
-      "time": "5:33"
-    },
+    { "title": "Copying tiles from the source image.", "time": "4:40" },
+    { "title": "Creating an Array for the board.", "time": "5:33" },
     { "title": "How does the board work?", "time": "6:54" },
-    {
-      "title": "Something went wrong?!?",
-      "time": "8:31"
-    },
-    {
-      "title": "Drawing borders between tiles.",
-      "time": "9:55"
-    },
+    { "title": "Something went wrong?!?", "time": "8:31" },
+    { "title": "Drawing borders between tiles.", "time": "9:55" },
     { "title": "Shuffling the board", "time": "10:57" },
-    {
-      "title": "Adding an empty tile.",
-      "time": "14:00"
-    },
-    {
-      "title": "Sliding a tile!",
-      "time": "14:52"
-    },
-    {
-      "title": "Checking tile neighbors.",
-      "time": "16:59"
-    },
-    {
-      "title": "Moving tiles in draw()",
-      "time": "19:37"
-    },
-    {
-      "title": "Moving tiles with mousePressed()",
-      "time": "20:12"
-    },
-    {
-      "title": "Is the puzzle solved?",
-      "time": "21:32"
-    },
+    { "title": "Adding an empty tile.", "time": "14:00" },
+    { "title": "Sliding a tile!", "time": "14:52" },
+    { "title": "Checking tile neighbors.", "time": "16:59" },
+    { "title": "Moving tiles in draw()", "time": "19:37" },
+    { "title": "Moving tiles with mousePressed()", "time": "20:12" },
+    { "title": "Is the puzzle solved?", "time": "21:32" },
     { "title": "Having fun with the tile grid!", "time": "23:06" },
     { "title": "Solving the puzzle!", "time": "23:55" },
     { "title": "What will you create?", "time": "24:27" }
@@ -119,13 +86,7 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/challenges/168-the-mandelbulb/index.json
+++ b/content/videos/challenges/168-the-mandelbulb/index.json
@@ -3,7 +3,7 @@
   "description": "It's the Mandelbulb! What happens when you take the original fractal (The Mandelbrot Set) and extend it into 3D space. And how do you visualize it in Processing (Java) as a point cloud?",
   "videoNumber": "168",
   "videoId": "NJCiUVGiNyA",
-  "date": "2022-03-09",
+  "date": "2022-03-11",
   "languages": ["Processing"],
   "topics": [
     "3D",
@@ -122,13 +122,7 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/challenges/173-snake-applesoft-basic/index.json
+++ b/content/videos/challenges/173-snake-applesoft-basic/index.json
@@ -3,7 +3,7 @@
   "description": "Take a trip back in time and let's code the Snake Game in AppleSoft BASIC on a restored Apple II+ computer! GOTO and GOSUB! Line numbers!",
   "videoNumber": "173",
   "videoId": "7r83N3c2kPw",
-  "date": "2022-08-23",
+  "date": "2022-08-24",
   "languages": ["BASIC"],
   "topics": ["games", "1980s", "AppleII"],
   "canContribute": true,
@@ -135,22 +135,13 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    },
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" },
     {
       "title": "Coding Together Theme",
       "name": "Will from America",
       "url": "https://twitter.com/WillfromAmerica"
     },
-    {
-      "title": "Eye of the Tiger cover",
-      "name": "Leon from @neo"
-    }
+    { "title": "Eye of the Tiger cover", "name": "Leon from @neo" }
   ]
 }

--- a/content/videos/challenges/54-islamic-star-patterns/index.json
+++ b/content/videos/challenges/54-islamic-star-patterns/index.json
@@ -3,7 +3,7 @@
   "description": "In this bonus super-sized coding challenge, I work through visualizing Islamic Star Patterns in p5.js.",
   "videoNumber": "54",
   "videoId": "sJ6pMLp_IaI",
-  "date": "2017-02-14",
+  "date": "2017-02-01",
   "languages": ["p5.js", "JavaScript"],
   "topics": [
     "islamic star patterns",
@@ -19,30 +19,12 @@
       "title": "Part 1 - Implementing the Star Patterns",
       "videoId": "sJ6pMLp_IaI",
       "timestamps": [
-        {
-          "time": "00:00",
-          "title": "Introduction"
-        },
-        {
-          "time": "03:10",
-          "title": "References and theory"
-        },
-        {
-          "time": "08:13",
-          "title": "Code! Creating Polygon and Edge objects"
-        },
-        {
-          "time": "14:46",
-          "title": "Closing the Polygon"
-        },
-        {
-          "time": "17:00",
-          "title": "Creating Hankin objects"
-        },
-        {
-          "time": "25:10",
-          "title": "Rotating the Hankin objects correctly"
-        },
+        { "time": "00:00", "title": "Introduction" },
+        { "time": "03:10", "title": "References and theory" },
+        { "time": "08:13", "title": "Code! Creating Polygon and Edge objects" },
+        { "time": "14:46", "title": "Closing the Polygon" },
+        { "time": "17:00", "title": "Creating Hankin objects" },
+        { "time": "25:10", "title": "Rotating the Hankin objects correctly" },
         {
           "time": "27:13",
           "title": "How to find the point of intersection of Hankins"
@@ -51,80 +33,32 @@
           "time": "30:21",
           "title": "Code! Implementing the math of intersection points"
         },
-        {
-          "time": "43:54",
-          "title": "Finding some of the intersection points"
-        },
-        {
-          "time": "49:40",
-          "title": "Finding all the intersection points"
-        },
-        {
-          "time": "51:17",
-          "title": "Getting rid of debugging stuff"
-        },
-        {
-          "time": "51:38",
-          "title": "Normalizing some vectors"
-        },
-        {
-          "time": "52:08",
-          "title": "Adding the delta on Hankins"
-        },
-        {
-          "time": "54:45",
-          "title": "Adding some sliders!"
-        },
-        {
-          "time": "57:43",
-          "title": "Creating the tiling"
-        },
+        { "time": "43:54", "title": "Finding some of the intersection points" },
+        { "time": "49:40", "title": "Finding all the intersection points" },
+        { "time": "51:17", "title": "Getting rid of debugging stuff" },
+        { "time": "51:38", "title": "Normalizing some vectors" },
+        { "time": "52:08", "title": "Adding the delta on Hankins" },
+        { "time": "54:45", "title": "Adding some sliders!" },
+        { "time": "57:43", "title": "Creating the tiling" },
         {
           "time": "1:00:02",
           "title": "What's missing from this implementation?"
         },
-        {
-          "time": "1:03:53",
-          "title": "Getting rid of the grid"
-        }
+        { "time": "1:03:53", "title": "Getting rid of the grid" }
       ]
     },
     {
       "title": "Part 2 - Refactoring using the Law of Sines",
       "videoId": "lobJ9gzbLo8",
       "timestamps": [
-        {
-          "time": "00:00",
-          "title": "Follow-up video opening"
-        },
-        {
-          "time": "00:28",
-          "title": "Community created version"
-        },
-        {
-          "time": "00:53",
-          "title": "Where we left off"
-        },
-        {
-          "time": "01:52",
-          "title": "How can we simplify the code?"
-        },
-        {
-          "time": "02:56",
-          "title": "What is the Law of Sines?"
-        },
-        {
-          "time": "08:36",
-          "title": "Code! Refactor to use the Law of Sines"
-        },
-        {
-          "time": "13:35",
-          "title": "Simplifying the Hankin object"
-        },
-        {
-          "time": "14:36",
-          "title": "Done! Wrapping up this Coding Challenge"
-        }
+        { "time": "00:00", "title": "Follow-up video opening" },
+        { "time": "00:28", "title": "Community created version" },
+        { "time": "00:53", "title": "Where we left off" },
+        { "time": "01:52", "title": "How can we simplify the code?" },
+        { "time": "02:56", "title": "What is the Law of Sines?" },
+        { "time": "08:36", "title": "Code! Refactor to use the Law of Sines" },
+        { "time": "13:35", "title": "Simplifying the Hankin object" },
+        { "time": "14:36", "title": "Done! Wrapping up this Coding Challenge" }
       ]
     }
   ],
@@ -238,13 +172,7 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/challenges/8-solar-system-3d/index.json
+++ b/content/videos/challenges/8-solar-system-3d/index.json
@@ -3,7 +3,7 @@
   "description": "In the second part of this coding challenge, using Processing, I take the code from the 2D Solar System and turn it three-dimensional.",
   "videoNumber": "8",
   "videoId": "dncudkelNxw",
-  "date": "2016-05-01",
+  "date": "2016-05-02",
   "languages": ["Processing"],
   "topics": ["solar system", "3d"],
   "canContribute": true,
@@ -55,13 +55,7 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/challenges/9-solar-system-3d-textures/index.json
+++ b/content/videos/challenges/9-solar-system-3d-textures/index.json
@@ -3,7 +3,7 @@
   "description": "In part 3 of this coding challenge, using Processing, I add textures to the 3D objects created in part 2. The PShape class and createShape() functions are covered.",
   "videoNumber": "9",
   "videoId": "FGAwi7wpU8c",
-  "date": "2016-05-01",
+  "date": "2016-05-02",
   "languages": ["Processing"],
   "topics": ["solar system", "3d", "textures"],
   "canContribute": true,
@@ -64,13 +64,7 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/challenges/c4-worley-noise/index.json
+++ b/content/videos/challenges/c4-worley-noise/index.json
@@ -3,7 +3,7 @@
   "description": "Coding in the Cabana is a series where I attempt challenges from my garden cabana in Brooklyn, NY. In this episode, I explore the beauty of Worley noise.",
   "videoNumber": "C4",
   "videoId": "4066MndcyCk",
-  "date": "2020-04-29",
+  "date": "2020-05-09",
   "languages": ["p5.js"],
   "topics": ["worley noise", "cellular texture", "tesselation", "distance"],
   "canContribute": true,
@@ -101,14 +101,9 @@
         }
       ]
     }
+  ],
+  "credits": [
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
-, "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]}
+}

--- a/content/videos/challenges/c5-marching-squares/index.json
+++ b/content/videos/challenges/c5-marching-squares/index.json
@@ -3,7 +3,7 @@
   "description": "In this episode of Coding in the Cabana, Gloria Pickle and I investigate the Marching Squares algorithm and apply it to Open Simplex Noise in Processing.",
   "videoNumber": "C5",
   "videoId": "0ZONMNUKTfU",
-  "date": "2020-07-14",
+  "date": "2020-07-17",
   "languages": ["Processing"],
   "topics": [
     "marching squares",
@@ -75,9 +75,7 @@
       "title": "Cave Generation",
       "description": "Visualization of marching squares for cave generation.",
       "image": "cave.png",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/z4U3Luf7o"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/z4U3Luf7o" }
     },
     {
       "title": "Metaballs Interpolation",
@@ -165,13 +163,7 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/code/0-trailer/trailer/index.json
+++ b/content/videos/code/0-trailer/trailer/index.json
@@ -9,13 +9,8 @@
   "codeExamples": [],
   "groupLinks": [],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-04-12"
 }

--- a/content/videos/code/1-intro/1-intro/index.json
+++ b/content/videos/code/1-intro/1-intro/index.json
@@ -47,13 +47,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2018-09-05"
 }

--- a/content/videos/code/1-intro/2-web-editor/index.json
+++ b/content/videos/code/1-intro/2-web-editor/index.json
@@ -17,9 +17,7 @@
       "title": "p5.js Web Editor Demo",
       "description": "Demonstration of p5.js Web Editor",
       "image": "",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/H1898NvwX"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/H1898NvwX" }
     }
   ],
   "groupLinks": [
@@ -53,13 +51,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2018-09-06"
 }

--- a/content/videos/code/2-variables/6-createGraphics/index.json
+++ b/content/videos/code/2-variables/6-createGraphics/index.json
@@ -3,14 +3,17 @@
   "description": "In this video, I cover createGraphics() in p5.js in order to demonstrate how to draw some shapes with trails and some without.",
   "videoNumber": "2.6",
   "videoId": "TaluaAD9MKA",
-  "date": "2019-02-03",
+  "date": "2019-02-13",
   "languages": ["p5.js", "JavaScript"],
   "topics": ["createGraphics"],
   "canContribute": true,
   "timestamps": [
     { "time": "0:00", "title": "Introduction" },
     { "time": "1:42", "title": "Create Two Canvases with createGraphics()" },
-    { "time": "3:45", "title": "Use clear() to Make the Extra Canvas Transparent" },
+    {
+      "time": "3:45",
+      "title": "Use clear() to Make the Extra Canvas Transparent"
+    },
     { "time": "5:00", "title": "Order of Shapes within Draw()" }
   ],
   "codeExamples": [
@@ -18,28 +21,18 @@
       "title": "Trails",
       "description": "Demonstration of using createGraphics() to overlay two different canvases.",
       "image": "img1.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/7RN7GFD-Y"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/7RN7GFD-Y" }
     },
     {
       "title": "Stars",
       "description": "Demonstration of using createGraphics() to overlay two different canvases.",
       "image": "img2.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/0kQ9v-bhM"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/0kQ9v-bhM" }
     }
   ],
   "groupLinks": [],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/code/5-functions/1-basics/index.json
+++ b/content/videos/code/5-functions/1-basics/index.json
@@ -3,13 +3,16 @@
   "description": "This video covers the basics of writing your own functions in JavaScript. What does it mean to define and call your own function? How can this make a program more modular?",
   "videoNumber": "5.1",
   "videoId": "wRHAitGzBrg",
-  "date": "2015-09-15",
+  "date": "2015-09-17",
   "languages": ["p5.js", "JavaScript"],
   "topics": ["basics", "function"],
   "canContribute": true,
   "timestamps": [
     { "time": "0:00", "title": "Introduction" },
-    { "time": "1:03", "title": "Calling a Function Versus Defining a Function" },
+    {
+      "time": "1:03",
+      "title": "Calling a Function Versus Defining a Function"
+    },
     { "time": "3:10", "title": "Modularity and Reusability" },
     { "time": "4:42", "title": "Code Example" },
     { "time": "6:30", "title": "Syntax of a Function" },
@@ -21,20 +24,12 @@
       "title": "Functions",
       "description": "Demonstration of using functions to modularize code.",
       "image": "img1.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/omHOuJY1"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/omHOuJY1" }
     }
   ],
   "groupLinks": [],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/code/6-objects/2-classes/index.json
+++ b/content/videos/code/6-objects/2-classes/index.json
@@ -3,7 +3,7 @@
   "description": "This video introduces Object-Oriented Programming in JavaScript with ES6 classes and the p5.js library.",
   "videoNumber": "6.2",
   "videoId": "T-HGdc8L-7w",
-  "date": "2017-6-10",
+  "date": "2017-10-06",
   "languages": ["p5.js", "JavaScript"],
   "topics": ["basics", "OOP", "objects"],
   "canContribute": true,
@@ -15,10 +15,7 @@
       "time": "8:40",
       "title": "The constructor() Function is the Object's Setup"
     },
-    {
-      "time": "10:10",
-      "title": "Using \"this.\" to Declare Class Variables"
-    },
+    { "time": "10:10", "title": "Using \"this.\" to Declare Class Variables" },
     { "time": "12:26", "title": "Code Example" },
     { "time": "14:50", "title": "Adding Functionality to a Class" }
   ],
@@ -27,20 +24,12 @@
       "title": "Classes",
       "description": "Demonstration of using a Bubble class to create multiple bubbles.",
       "image": "img1.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/qi7N4LWq"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/qi7N4LWq" }
     }
   ],
   "groupLinks": [],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/code/7-arrays/upload-editor/index.json
+++ b/content/videos/code/7-arrays/upload-editor/index.json
@@ -2,7 +2,7 @@
   "title": "p5.js Web Editor: Uploading Media Files",
   "description": "In this video, I show how to upload media files to the p5.js web editor for use in p5.js sketches.",
   "videoId": "rO6M5hj0V-o",
-  "date": "2018-10-6",
+  "date": "2018-10-06",
   "languages": ["p5.js"],
   "topics": ["web editor", "media files"],
   "canContribute": true,
@@ -32,13 +32,7 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/data/1-client-side/1-fetch/index.json
+++ b/content/videos/data/1-client-side/1-fetch/index.json
@@ -83,13 +83,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-05-17"
 }

--- a/content/videos/data/1-client-side/2-tabular-data/index.json
+++ b/content/videos/data/1-client-side/2-tabular-data/index.json
@@ -72,13 +72,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-05-23"
 }

--- a/content/videos/data/1-client-side/3-graphing/index.json
+++ b/content/videos/data/1-client-side/3-graphing/index.json
@@ -57,13 +57,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-05-23"
 }

--- a/content/videos/data/1-client-side/4-json/index.json
+++ b/content/videos/data/1-client-side/4-json/index.json
@@ -45,13 +45,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-05-25"
 }

--- a/content/videos/data/1-client-side/5-mapping-geolocation/index.json
+++ b/content/videos/data/1-client-side/5-mapping-geolocation/index.json
@@ -56,13 +56,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-05-27"
 }

--- a/content/videos/data/1-client-side/6-refreshing-data-with-setinterval/index.json
+++ b/content/videos/data/1-client-side/6-refreshing-data-with-setinterval/index.json
@@ -83,13 +83,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-05-29"
 }

--- a/content/videos/data/2-data-selfie-app/1-server-side-with-node-js/index.json
+++ b/content/videos/data/2-data-selfie-app/1-server-side-with-node-js/index.json
@@ -96,13 +96,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-05-30"
 }

--- a/content/videos/data/2-data-selfie-app/2-geolocation-web-api/index.json
+++ b/content/videos/data/2-data-selfie-app/2-geolocation-web-api/index.json
@@ -61,13 +61,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-05-31"
 }

--- a/content/videos/data/2-data-selfie-app/3-http-post-request/index.json
+++ b/content/videos/data/2-data-selfie-app/3-http-post-request/index.json
@@ -67,13 +67,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-06-03"
 }

--- a/content/videos/data/2-data-selfie-app/4-saving-to-a-database/index.json
+++ b/content/videos/data/2-data-selfie-app/4-saving-to-a-database/index.json
@@ -96,13 +96,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-06-04"
 }

--- a/content/videos/data/2-data-selfie-app/5-database-query/index.json
+++ b/content/videos/data/2-data-selfie-app/5-database-query/index.json
@@ -39,13 +39,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-06-05"
 }

--- a/content/videos/data/2-data-selfie-app/6-encoding-images/index.json
+++ b/content/videos/data/2-data-selfie-app/6-encoding-images/index.json
@@ -82,13 +82,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-06-06"
 }

--- a/content/videos/data/2-data-selfie-app/7-accessibility-and-design/index.json
+++ b/content/videos/data/2-data-selfie-app/7-accessibility-and-design/index.json
@@ -81,13 +81,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-06-07"
 }

--- a/content/videos/data/3-the-weather-here/1-api-calls-from-node-js/index.json
+++ b/content/videos/data/3-the-weather-here/1-api-calls-from-node-js/index.json
@@ -66,13 +66,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-06-12"
 }

--- a/content/videos/data/3-the-weather-here/2-open-air-quality-api/index.json
+++ b/content/videos/data/3-the-weather-here/2-open-air-quality-api/index.json
@@ -80,13 +80,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-06-13"
 }

--- a/content/videos/data/3-the-weather-here/3-mapping-database-entries/index.json
+++ b/content/videos/data/3-the-weather-here/3-mapping-database-entries/index.json
@@ -58,13 +58,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-06-14"
 }

--- a/content/videos/data/3-the-weather-here/4-environment-variables/index.json
+++ b/content/videos/data/3-the-weather-here/4-environment-variables/index.json
@@ -65,13 +65,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-06-17"
 }

--- a/content/videos/data/3-the-weather-here/5-web-application-deployment/index.json
+++ b/content/videos/data/3-the-weather-here/5-web-application-deployment/index.json
@@ -53,13 +53,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-06-28"
 }

--- a/content/videos/data/welcome/setup/index.json
+++ b/content/videos/data/welcome/setup/index.json
@@ -84,13 +84,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-07-09"
 }

--- a/content/videos/data/welcome/trailer/index.json
+++ b/content/videos/data/welcome/trailer/index.json
@@ -20,13 +20,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2019-07-08"
 }

--- a/content/videos/git/1-fundamentals/1-intro/index.json
+++ b/content/videos/git/1-fundamentals/1-intro/index.json
@@ -18,9 +18,7 @@
     {
       "title": "Rainbow Poem",
       "description": "GitHub repo for the Rainbow Poem",
-      "urls": {
-        "other": "https://github.com/CodingTrain/Rainbow-Poem"
-      }
+      "urls": { "other": "https://github.com/CodingTrain/Rainbow-Poem" }
     }
   ],
   "groupLinks": [
@@ -43,13 +41,8 @@
   ],
   "canContribute": false,
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2016-04-19"
 }

--- a/content/videos/git/1-fundamentals/10-git-remotes/index.json
+++ b/content/videos/git/1-fundamentals/10-git-remotes/index.json
@@ -14,9 +14,7 @@
     {
       "title": "Flappy Bird Clone",
       "description": "GitHub repo for The Coding Train's Flappy Bird Clone ",
-      "urls": {
-        "other": "https://github.com/CodingTrain/Flappy-Bird-Clone"
-      }
+      "urls": { "other": "https://github.com/CodingTrain/Flappy-Bird-Clone" }
     }
   ],
   "groupLinks": [
@@ -39,13 +37,8 @@
   ],
   "canContribute": false,
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2018-03-16"
 }

--- a/content/videos/git/1-fundamentals/2-branches/index.json
+++ b/content/videos/git/1-fundamentals/2-branches/index.json
@@ -14,9 +14,7 @@
     {
       "title": "Rainbow Poem",
       "description": "GitHub repo for the Rainbow Poem",
-      "urls": {
-        "other": "https://github.com/CodingTrain/Rainbow-Poem"
-      }
+      "urls": { "other": "https://github.com/CodingTrain/Rainbow-Poem" }
     }
   ],
   "groupLinks": [
@@ -39,13 +37,8 @@
   ],
   "canContribute": false,
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2016-04-19"
 }

--- a/content/videos/git/1-fundamentals/3-forks-pr/index.json
+++ b/content/videos/git/1-fundamentals/3-forks-pr/index.json
@@ -15,9 +15,7 @@
     {
       "title": "Rainbow Poem",
       "description": "GitHub repo for the Rainbow Poem",
-      "urls": {
-        "other": "https://github.com/CodingTrain/Rainbow-Poem"
-      }
+      "urls": { "other": "https://github.com/CodingTrain/Rainbow-Poem" }
     }
   ],
   "groupLinks": [
@@ -40,13 +38,8 @@
   ],
   "canContribute": false,
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2016-04-23"
 }

--- a/content/videos/git/1-fundamentals/4-issues/index.json
+++ b/content/videos/git/1-fundamentals/4-issues/index.json
@@ -15,9 +15,7 @@
     {
       "title": "Rainbow Poem",
       "description": "GitHub repo for the Rainbow Poem",
-      "urls": {
-        "other": "https://github.com/CodingTrain/Rainbow-Poem"
-      }
+      "urls": { "other": "https://github.com/CodingTrain/Rainbow-Poem" }
     }
   ],
   "groupLinks": [
@@ -40,13 +38,8 @@
   ],
   "canContribute": false,
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2016-04-24"
 }

--- a/content/videos/git/1-fundamentals/5-command-line/index.json
+++ b/content/videos/git/1-fundamentals/5-command-line/index.json
@@ -16,9 +16,7 @@
     {
       "title": "Rainbow Poem",
       "description": "GitHub repo for the Rainbow Poem",
-      "urls": {
-        "other": "https://github.com/CodingTrain/Rainbow-Poem"
-      }
+      "urls": { "other": "https://github.com/CodingTrain/Rainbow-Poem" }
     }
   ],
   "groupLinks": [
@@ -41,13 +39,8 @@
   ],
   "canContribute": false,
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2016-05-04"
 }

--- a/content/videos/git/1-fundamentals/6-cloning-repo/index.json
+++ b/content/videos/git/1-fundamentals/6-cloning-repo/index.json
@@ -6,7 +6,10 @@
   "videoId": "yXT1ElMEkW8",
   "timestamps": [
     { "time": "0:00", "title": "Introduction" },
-    { "time": "1:08", "title": "Checking that git is installed on your computer" },
+    {
+      "time": "1:08",
+      "title": "Checking that git is installed on your computer"
+    },
     { "time": "3:03", "title": "Cloning a GitHub repo" },
     { "time": "7:40", "title": "git status and git commit" },
     { "time": "9:52", "title": "Configuring git on your computer" },
@@ -19,9 +22,7 @@
     {
       "title": "Rainbow Song",
       "description": "GitHub repo for the Rainbow Song",
-      "urls": {
-        "other": "https://github.com/CodingTrain/Rainbow-Song"
-      }
+      "urls": { "other": "https://github.com/CodingTrain/Rainbow-Song" }
     }
   ],
   "groupLinks": [
@@ -50,13 +51,8 @@
   ],
   "canContribute": false,
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2016-05-04"
 }

--- a/content/videos/git/1-fundamentals/7-git-init/index.json
+++ b/content/videos/git/1-fundamentals/7-git-init/index.json
@@ -17,9 +17,7 @@
     {
       "title": "Rainbow Dance",
       "description": "GitHub repo for the Rainbow Dance",
-      "urls": {
-        "other": "https://github.com/CodingTrain/Rainbow-Dance"
-      }
+      "urls": { "other": "https://github.com/CodingTrain/Rainbow-Dance" }
     }
   ],
   "groupLinks": [
@@ -48,13 +46,8 @@
   ],
   "canContribute": false,
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2016-05-17"
 }

--- a/content/videos/git/1-fundamentals/8-pages/index.json
+++ b/content/videos/git/1-fundamentals/8-pages/index.json
@@ -15,9 +15,7 @@
     {
       "title": "Poem Website",
       "description": "GitHub repo for the Poem Website",
-      "urls": {
-        "other": "https://github.com/CodingTrain/PoemWebsite"
-      }
+      "urls": { "other": "https://github.com/CodingTrain/PoemWebsite" }
     }
   ],
   "groupLinks": [
@@ -50,13 +48,8 @@
   ],
   "canContribute": false,
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2016-06-02"
 }

--- a/content/videos/git/1-fundamentals/9-resolve-conflicts/index.json
+++ b/content/videos/git/1-fundamentals/9-resolve-conflicts/index.json
@@ -50,13 +50,8 @@
   ],
   "canContribute": false,
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2018-02-15"
 }

--- a/content/videos/mastodon/what-is-node-js/index.json
+++ b/content/videos/mastodon/what-is-node-js/index.json
@@ -3,7 +3,7 @@
   "description": "This video covers the basics of Node.js. What is Node.js? What is server-side programming? What might you use it for and how do you get started?  Basic unix commands and working with terminal are covered.",
   "videoNumber": "15.1",
   "videoId": "RF5_MPSNAtU",
-  "date": "2018-10-08",
+  "date": "2015-11-12",
   "languages": ["node.js"],
   "topics": ["twitter", "bot"],
   "canContribute": false,
@@ -62,13 +62,7 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/ml5/1-classification/3-object-detection/index.json
+++ b/content/videos/ml5/1-classification/3-object-detection/index.json
@@ -3,7 +3,7 @@
   "description": "I cover object detection in ml5.js with the COCO-SSD pre-trained model.",
   "videoNumber": "1.3",
   "videoId": "QEzRxnuaZCk",
-  "date": "2020-10-14",
+  "date": "2020-10-20",
   "languages": ["p5.js", "ml5.js"],
   "topics": [
     "coco-ssd",
@@ -31,23 +31,17 @@
       "title": "Object detection (image)",
       "description": "Object detection with COCO",
       "image": "object.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/ZNQQx2n5o"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/ZNQQx2n5o" }
     },
     {
       "title": "Object detection webcam",
       "description": "Object detection with COCO",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/VIYRpcME3"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/VIYRpcME3" }
     },
     {
       "title": "Object detection webcam persistence",
       "description": "Code example 1 description",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/Vt9xeTxWJ"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/Vt9xeTxWJ" }
     }
   ],
   "groupLinks": [
@@ -135,13 +129,7 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/ml5/6-train-your-own-neural-network/2-save-data/index.json
+++ b/content/videos/ml5/6-train-your-own-neural-network/2-save-data/index.json
@@ -3,7 +3,7 @@
   "description": "This video takes the sketch from the previous video on training your own ml5.js neural network, and shows how to save the data collected in a JSON file which can be loaded again later.",
   "videoNumber": "6.2",
   "videoId": "q6cwxORPDo8",
-  "date": "YYYY-MM-DD",
+  "date": "2019-12-05",
   "languages": ["ml5.js", "p5.js"],
   "topics": ["neural network", "machine learning", "saving data"],
   "canContribute": true,
@@ -22,9 +22,7 @@
     {
       "title": "Save neural network training data",
       "description": "This sketch demonstrates how to save neural network training data.",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/4fxtImOMz"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/4fxtImOMz" }
     }
   ],
   "groupLinks": [
@@ -41,13 +39,7 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/ml5/6-train-your-own-neural-network/3-save-model/index.json
+++ b/content/videos/ml5/6-train-your-own-neural-network/3-save-model/index.json
@@ -2,7 +2,7 @@
   "title": "ml5.js: Save Neural Network Trained Model",
   "description": "Here I show how you to save a model that has been trained in ml5.js. You can then load (aka \"deploy\") that model later (\"pre-trained model\") in another sketch!",
   "videoNumber": "6.3",
-  "videoId": "xwUrg9Hjkhg0",
+  "videoId": "wUrg9Hjkhg0",
   "date": "2019-12-05",
   "languages": ["ml5.js", "p5.js"],
   "topics": ["saving data", "neural network", "machine learning"],

--- a/content/videos/ml5/8-convolutional-neural-network/2-architecture-of-cnn/index.json
+++ b/content/videos/ml5/8-convolutional-neural-network/2-architecture-of-cnn/index.json
@@ -3,115 +3,53 @@
   "description": "This video covers the architecture of a Convolutional Neural Network, focusing on the concept of \"filters\".",
   "videoNumber": "8.2",
   "videoId": "qPKsVAI_W6M",
-  "date": "2020-02-14",
+  "date": "2020-02-23",
   "languages": ["ml5.js", "p5.js"],
   "topics": ["convolutional neural network", "machine learning"],
   "canContribute": true,
   "timestamps": [
-    {
-      "time": "0:00",
-      "title": "Introduction"
-    },
-    {
-      "time": "1:28",
-      "title": "Review neural networks"
-    },
+    { "time": "0:00", "title": "Introduction" },
+    { "time": "1:28", "title": "Review neural networks" },
     {
       "time": "3:34",
       "title": "Flattenng the image causes a loss of information"
     },
-    {
-      "time": "4:18",
-      "title": "Convolutional layer"
-    },
-    {
-      "time": "4:37",
-      "title": "Filter"
-    },
-    {
-      "time": "5:08",
-      "title": "Gradient based learning"
-    },
-    {
-      "time": "6:21",
-      "title": "Filter is a matrix of numbers"
-    },
-    {
-      "time": "6:59",
-      "title": "Photoshop"
-    },
-    {
-      "time": "7:14",
-      "title": "Known filters draw out different features"
-    },
+    { "time": "4:18", "title": "Convolutional layer" },
+    { "time": "4:37", "title": "Filter" },
+    { "time": "5:08", "title": "Gradient based learning" },
+    { "time": "6:21", "title": "Filter is a matrix of numbers" },
+    { "time": "6:59", "title": "Photoshop" },
+    { "time": "7:14", "title": "Known filters draw out different features" },
     {
       "time": "8:59",
       "title": "Neural network learn filters that identify features"
     },
-    {
-      "time": "10:25",
-      "title": "Blurring an image"
-    },
+    { "time": "10:25", "title": "Blurring an image" },
     {
       "time": "11:12",
       "title": "Coding a convolutional neural network in p5js"
     },
-    {
-      "time": "11:56",
-      "title": "Create a filtered image"
-    },
-    {
-      "time": "13:10",
-      "title": "Ignore the edge pixels"
-    },
-    {
-      "time": "13:42",
-      "title": "Convolution function"
-    },
+    { "time": "11:56", "title": "Create a filtered image" },
+    { "time": "13:10", "title": "Ignore the edge pixels" },
+    { "time": "13:42", "title": "Convolution function" },
     {
       "time": "15:28",
       "title": "Finding the one-dimenstional look-up into matrix"
     },
-    {
-      "time": "16:16",
-      "title": "Four numbers are stored for every pixel"
-    },
-    {
-      "time": "16:36",
-      "title": "Sum r, g, b values"
-    },
-    {
-      "time": "20:46",
-      "title": "Multiply by filter"
-    },
-    {
-      "time": "22:37",
-      "title": "Get filtered pixels"
-    },
-    {
-      "time": "23:13",
-      "title": "Call loadPixels"
-    },
-    {
-      "time": "23:34",
-      "title": "Call updataPixels"
-    },
-    {
-      "time": "24:40",
-      "title": "Change the indices to find vertical edges"
-    },
-    {
-      "time": "26:11",
-      "title": "Add a random filter"
-    }
+    { "time": "16:16", "title": "Four numbers are stored for every pixel" },
+    { "time": "16:36", "title": "Sum r, g, b values" },
+    { "time": "20:46", "title": "Multiply by filter" },
+    { "time": "22:37", "title": "Get filtered pixels" },
+    { "time": "23:13", "title": "Call loadPixels" },
+    { "time": "23:34", "title": "Call updataPixels" },
+    { "time": "24:40", "title": "Change the indices to find vertical edges" },
+    { "time": "26:11", "title": "Add a random filter" }
   ],
   "codeExamples": [
     {
       "title": "Convlutional Neural Network",
       "description": "This sketch demonstrates the process of creating a convolutional layer to filter pixels.",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/BN1lE-gyl"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/BN1lE-gyl" }
     }
   ],
   "groupLinks": [
@@ -157,13 +95,7 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/ml5/8-convolutional-neural-network/3-max-pooling/index.json
+++ b/content/videos/ml5/8-convolutional-neural-network/3-max-pooling/index.json
@@ -3,7 +3,7 @@
   "description": "Part 2 of this video on Convolutional Neural Networks covers on the concept of \"max pooling.\"",
   "videoNumber": "8.3",
   "videoId": "pRWq_mtuppU",
-  "date": "2020-02-14",
+  "date": "2020-02-24",
   "languages": ["ml5.js", "JavaScript"],
   "topics": ["max pooling", "convolutional neural network", "stride"],
   "canContribute": true,
@@ -26,9 +26,7 @@
     {
       "title": "Convolutional Neural network",
       "description": "This sketch demonstrates max pooling.",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/GMRfsK7Wn"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/GMRfsK7Wn" }
     }
   ],
   "groupLinks": [
@@ -68,13 +66,7 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/ml5/8-convolutional-neural-network/4-image-classification/index.json
+++ b/content/videos/ml5/8-convolutional-neural-network/4-image-classification/index.json
@@ -3,78 +3,38 @@
   "description": "In this video, I update the previous classification example (with pixels) and incorporate a convolutional neural network in ml5.js!",
   "videoNumber": "8.4",
   "videoId": "hWurN0XhzLY",
-  "date": "2020-11-20",
+  "date": "2020-11-25",
   "languages": ["ml5.js", "p5.js"],
   "topics": ["convolutional neural network", "image classification"],
   "canContribute": true,
   "timestamps": [
-    {
-      "time": "0:00",
-      "title": "Introduction"
-    },
-    {
-      "time": "0:45",
-      "title": "Errors in previous video"
-    },
-    {
-      "time": "1:46",
-      "title": "Review training with pixels"
-    },
-    {
-      "time": "2:37",
-      "title": "Update to the ml library"
-    },
-    {
-      "time": "2:53",
-      "title": "Specifiy the task: image classification"
-    },
-    {
-      "time": "3:31",
-      "title": "Specify the characteristics of the data"
-    },
-    {
-      "time": "5:11",
-      "title": "Adjust addExample function"
-    },
-    {
-      "time": "7:11",
-      "title": "Train the model"
-    },
-    {
-      "time": "8:09",
-      "title": "Debugging:  loss is not decreasing"
-    },
-    {
-      "time": "8:53",
-      "title": "normalizeData()"
-    },
+    { "time": "0:00", "title": "Introduction" },
+    { "time": "0:45", "title": "Errors in previous video" },
+    { "time": "1:46", "title": "Review training with pixels" },
+    { "time": "2:37", "title": "Update to the ml library" },
+    { "time": "2:53", "title": "Specifiy the task: image classification" },
+    { "time": "3:31", "title": "Specify the characteristics of the data" },
+    { "time": "5:11", "title": "Adjust addExample function" },
+    { "time": "7:11", "title": "Train the model" },
+    { "time": "8:09", "title": "Debugging:  loss is not decreasing" },
+    { "time": "8:53", "title": "normalizeData()" },
     {
       "time": "10:07",
       "title": "Why use the convolutional neural network in ml5?"
     },
-    {
-      "time": "12:03",
-      "title": "Mask versus No mask"
-    },
-    {
-      "time": "14:48",
-      "title": "Defining custom layers"
-    }
+    { "time": "12:03", "title": "Mask versus No mask" },
+    { "time": "14:48", "title": "Defining custom layers" }
   ],
   "codeExamples": [
     {
       "title": "Training a convolutional neural network",
       "description": "This sketch shows how to incorporate a convolutional neural network.",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/ogxO8har_"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/ogxO8har_" }
     },
     {
       "title": "Mask",
       "description": "This sketch classifies whether a person is wearing a mask.",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/tKLoeUD0u"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/tKLoeUD0u" }
     }
   ],
   "groupLinks": [
@@ -114,13 +74,7 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/ml5/9-doodleNet/1-doodleNet/index.json
+++ b/content/videos/ml5/9-doodleNet/1-doodleNet/index.json
@@ -3,81 +3,39 @@
   "description": "Quick, draw! In this video, I demonstrate how to use the DoodleNet pre-trained machine learning model to classify drawings of cats, strawberries, and other common doodles in JavaScript (with p5.js and ml5.js).",
   "videoNumber": "9.1",
   "videoId": "ABN_DWnM5GQ",
-  "date": "2020-12-01",
+  "date": "2020-12-09",
   "languages": ["ml5.js", "JavaScript"],
   "topics": ["DoodleNet", "machine learning", "doodle classifier"],
   "canContribute": true,
   "timestamps": [
-    {
-      "time": "0:00",
-      "title": "Introduction"
-    },
-    {
-      "time": "1:35",
-      "title": "doodleClassifier"
-    },
-    {
-      "time": "3:24",
-      "title": "Console logging results"
-    },
-    {
-      "time": "4:31",
-      "title": "ResultsDiv and loop classification"
-    },
-    {
-      "time": "6:51",
-      "title": "Drawing a cat"
-    },
-    {
-      "time": "8:17",
-      "title": "Make it work with video"
-    },
-    {
-      "time": "8:59",
-      "title": "Draw a strawberry"
-    },
-    {
-      "time": "9:11",
-      "title": "Add threshold"
-    },
-    {
-      "time": "9:44",
-      "title": "Try a thicker pen"
-    },
-    {
-      "time": "10:26",
-      "title": "Threshold on/off"
-    },
-    {
-      "time": "10:51",
-      "title": "Draw a snowman"
-    },
-    {
-      "time": "11:13",
-      "title": "Wrap up!"
-    }
+    { "time": "0:00", "title": "Introduction" },
+    { "time": "1:35", "title": "doodleClassifier" },
+    { "time": "3:24", "title": "Console logging results" },
+    { "time": "4:31", "title": "ResultsDiv and loop classification" },
+    { "time": "6:51", "title": "Drawing a cat" },
+    { "time": "8:17", "title": "Make it work with video" },
+    { "time": "8:59", "title": "Draw a strawberry" },
+    { "time": "9:11", "title": "Add threshold" },
+    { "time": "9:44", "title": "Try a thicker pen" },
+    { "time": "10:26", "title": "Threshold on/off" },
+    { "time": "10:51", "title": "Draw a snowman" },
+    { "time": "11:13", "title": "Wrap up!" }
   ],
   "codeExamples": [
     {
       "title": "Starting Template",
       "description": "This sketch creates a doodling canvas.",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/AHgkwgPdc"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/AHgkwgPdc" }
     },
     {
       "title": "Mouse",
       "description": "This sketch classifies doodles created with a mouse.",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/6LLnGY1VY"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/6LLnGY1VY" }
     },
     {
       "title": "Video",
       "description": "This sketch classifies images from a webcam.",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/fxFKOn3il"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/fxFKOn3il" }
     }
   ],
   "groupLinks": [
@@ -123,13 +81,7 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
   ]
 }

--- a/content/videos/noc/1-vectors/1-what-is-a-vector/index.json
+++ b/content/videos/noc/1-vectors/1-what-is-a-vector/index.json
@@ -11,9 +11,7 @@
       "title": "What is a Vector",
       "description": "Creating a walker object that moves along a random vector while drawing on the canvas",
       "image": "image1.png",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/JmEToUfk"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/JmEToUfk" }
     }
   ],
   "groupLinks": [
@@ -44,13 +42,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2020-03-07"
 }

--- a/content/videos/noc/1-vectors/2-vector-math/index.json
+++ b/content/videos/noc/1-vectors/2-vector-math/index.json
@@ -11,9 +11,7 @@
       "title": "Vector Math",
       "description": "Using vector addition to move a circle across the screen",
       "image": "image1.png",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/GGn5cd-z"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/GGn5cd-z" }
     }
   ],
   "groupLinks": [
@@ -34,13 +32,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2020-03-11"
 }

--- a/content/videos/noc/1-vectors/3-random-vectors/index.json
+++ b/content/videos/noc/1-vectors/3-random-vectors/index.json
@@ -11,17 +11,13 @@
       "title": "Random Vector",
       "description": "Draws a cluster of random vectors to the canvas",
       "image": "image1.png",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/qHKMdpRR"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/qHKMdpRR" }
     },
     {
       "title": "Walker",
       "description": "Creates a Walker object that can move on its own",
       "image": "image2.png",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/_HHLfcGx"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/_HHLfcGx" }
     }
   ],
   "groupLinks": [
@@ -42,13 +38,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2020-03-16"
 }

--- a/content/videos/noc/1-vectors/4-static-functions/index.json
+++ b/content/videos/noc/1-vectors/4-static-functions/index.json
@@ -24,13 +24,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2020-03-19"
 }

--- a/content/videos/noc/1-vectors/5-unit-vector/index.json
+++ b/content/videos/noc/1-vectors/5-unit-vector/index.json
@@ -11,9 +11,7 @@
       "title": "Unit Vector (Normalize)",
       "description": "Creates a unit vector that points at the mouse",
       "image": "image1.png",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/U4ezFLIZ"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/U4ezFLIZ" }
     }
   ],
   "groupLinks": [
@@ -49,13 +47,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2020-03-21"
 }

--- a/content/videos/noc/1-vectors/6-acceleration-vector/index.json
+++ b/content/videos/noc/1-vectors/6-acceleration-vector/index.json
@@ -11,19 +11,12 @@
       "title": "Acceleration Vector",
       "description": "Creates a mover object that chases after the mouse",
       "image": "image1.png",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/OjCfrdWX"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/OjCfrdWX" }
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2020-03-22"
 }

--- a/content/videos/noc/2-forces/1-gravity-and-wind/index.json
+++ b/content/videos/noc/2-forces/1-gravity-and-wind/index.json
@@ -11,9 +11,7 @@
       "title": "Simulating Forces",
       "description": "Simulating a wind force when the mouse is pressed",
       "image": "image1.png",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/kYWcOmch"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/kYWcOmch" }
     }
   ],
   "groupLinks": [
@@ -34,13 +32,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2020-03-27"
 }

--- a/content/videos/noc/2-forces/2-mass-and-acceleration/index.json
+++ b/content/videos/noc/2-forces/2-mass-and-acceleration/index.json
@@ -34,13 +34,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2020-03-31"
 }

--- a/content/videos/noc/2-forces/3-friction-force/index.json
+++ b/content/videos/noc/2-forces/3-friction-force/index.json
@@ -11,33 +11,25 @@
       "title": "Friction Force",
       "description": "Simulating friction on objects with weight",
       "image": "friction.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/zcTpMCpA"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/zcTpMCpA" }
     },
     {
       "title": "Top Down Billiards Exercise",
       "description": "Simulating a billiards table",
       "image": "billiards.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/S3SCcnUa7"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/S3SCcnUa7" }
     },
     {
       "title": "Slope Exercise",
       "description": "Simulating objects on a sloped surface",
       "image": "slope.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/LS5FlhljG"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/LS5FlhljG" }
     },
     {
       "title": "Show Vectors Exercise",
       "description": "Using arrows to show the force vectors acting on an object",
       "image": "show.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/Vyg_iWNGE"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/Vyg_iWNGE" }
     }
   ],
   "groupLinks": [
@@ -63,13 +55,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2020-04-08"
 }

--- a/content/videos/noc/2-forces/4-drag-force/index.json
+++ b/content/videos/noc/2-forces/4-drag-force/index.json
@@ -11,25 +11,19 @@
       "title": "Drag Force",
       "description": "Simulating different drag forces on objects",
       "image": "drag.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/5V8nSBOS"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/5V8nSBOS" }
     },
     {
       "title": "Goose and the Jello Cubes of Varying Densities",
       "description": "Play as Goose and avoid the jello cubes!",
       "image": "jello.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/O36gAqVqt"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/O36gAqVqt" }
     },
     {
       "title": "Surface Area Exercise",
       "description": "Demonstrating drag force on objects with varying surface areas",
       "image": "surface.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/hHDqBfOCt"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/hHDqBfOCt" }
     }
   ],
   "groupLinks": [
@@ -50,13 +44,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2020-04-11"
 }

--- a/content/videos/noc/2-forces/5-gravitational-attraction/index.json
+++ b/content/videos/noc/2-forces/5-gravitational-attraction/index.json
@@ -11,17 +11,13 @@
       "title": "Gravitational Attraction",
       "description": "Simulating gravitational attraction between objects",
       "image": "code1.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/MkLraatd"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/MkLraatd" }
     },
     {
       "title": "Attraction Exercise",
       "description": "Creating attractor objects with positive and negative gravity force",
       "image": "code2.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/ImehzZuCU"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/ImehzZuCU" }
     }
   ],
   "groupLinks": [
@@ -57,13 +53,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2020-04-23"
 }

--- a/content/videos/noc/3-angles/1-angles-and-rotation/index.json
+++ b/content/videos/noc/3-angles/1-angles-and-rotation/index.json
@@ -11,9 +11,7 @@
       "title": "Angles and Rotation",
       "description": "Demonstrating rotation of a rectangle in p5.js",
       "image": "angles.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/y7ieDesyd"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/y7ieDesyd" }
     }
   ],
   "groupLinks": [
@@ -39,13 +37,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2021-01-26"
 }

--- a/content/videos/noc/3-angles/2-angular-motion/index.json
+++ b/content/videos/noc/3-angles/2-angular-motion/index.json
@@ -11,25 +11,19 @@
       "title": "Rectangle Acceleration",
       "description": "Demonstrating acceleration of angular motion on a rectangle",
       "image": "rect.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/RR9XUN1mf"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/RR9XUN1mf" }
     },
     {
       "title": "Rectangle Grab Exercise",
       "description": "Clicking and dragging to change a rectangle's angular momentum",
       "image": "grab.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/In9e8j6t_"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/In9e8j6t_" }
     },
     {
       "title": "Gravitational Attraction",
       "description": "Adding angular motion to a previous sketch demonstrating gravitational attraction",
       "image": "gravitation.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/Y-yxvkkZk"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/Y-yxvkkZk" }
     }
   ],
   "groupLinks": [
@@ -50,13 +44,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2021-01-29"
 }

--- a/content/videos/noc/3-angles/3-angles-and-vectors/index.json
+++ b/content/videos/noc/3-angles/3-angles-and-vectors/index.json
@@ -11,9 +11,7 @@
       "title": "Direction Pointing",
       "description": "Creating Mover objects that point in the irection they're moving",
       "image": "direction.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/9M9yQJVVc"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/9M9yQJVVc" }
     },
     {
       "title": "Vehicle",
@@ -27,9 +25,7 @@
       "title": "Asteroids Exercise",
       "description": "A spaceship with direction and thrust controls",
       "image": "asteroids.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/pXS395i0h"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/pXS395i0h" }
     }
   ],
   "groupLinks": [
@@ -60,13 +56,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2021-02-02"
 }

--- a/content/videos/noc/3-angles/4-polar-coordinates/index.json
+++ b/content/videos/noc/3-angles/4-polar-coordinates/index.json
@@ -11,33 +11,25 @@
       "title": "Basic Polar Coordinates",
       "description": "A simple example of using polar coordinates in p5.js",
       "image": "basic.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/DHetsOfgz"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/DHetsOfgz" }
     },
     {
       "title": "Spiral",
       "description": "Using polar coordinates to draw a spiral",
       "image": "spiral.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/BnJ_4U4cr"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/BnJ_4U4cr" }
     },
     {
       "title": "Random Trail",
       "description": "Drawing a glowing trail with polar coordinates",
       "image": "trail.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/WqK-qD1vU"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/WqK-qD1vU" }
     },
     {
       "title": "Circular Shape",
       "description": "Drawing a random circular shape with polar coordinates",
       "image": "circlular.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/s10TQXDZv"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/s10TQXDZv" }
     }
   ],
   "groupLinks": [
@@ -83,13 +75,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2021-02-06"
 }

--- a/content/videos/noc/3-angles/5-harmonic-motion/index.json
+++ b/content/videos/noc/3-angles/5-harmonic-motion/index.json
@@ -11,49 +11,37 @@
       "title": "Basic",
       "description": "Drawing a growing circle using harmonic motion",
       "image": "basic.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/Fn1feR81W"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/Fn1feR81W" }
     },
     {
       "title": "Approximate Time",
       "description": "Generating oscillating motion without an exact time increment",
       "image": "basic.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/uGCYH4-PN"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/uGCYH4-PN" }
     },
     {
       "title": "Exact Time Exercise",
       "description": "Generating oscillating motion using a specific amount of milliseconds to determine the period",
       "image": "time.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/jp2B-0Wkg"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/jp2B-0Wkg" }
     },
     {
       "title": "Main",
       "description": "Drawing oscillating motion that accelerates over time",
       "image": "basic.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/MfvyVULHT"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/MfvyVULHT" }
     },
     {
       "title": "Yoyo",
       "description": "Using oscillating motion to animate a yoyo",
       "image": "yoyo.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/qBhVjZ0pn"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/qBhVjZ0pn" }
     },
     {
       "title": "2-Axes Exercise",
       "description": "Simulating oscillating motion along two axes",
       "image": "axis.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/_ir7-suNG"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/_ir7-suNG" }
     }
   ],
   "groupLinks": [
@@ -74,13 +62,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2021-02-07"
 }

--- a/content/videos/noc/3-angles/6-graphing-sine-wave/index.json
+++ b/content/videos/noc/3-angles/6-graphing-sine-wave/index.json
@@ -11,43 +11,30 @@
       "title": "Sine Wave Graph Exercise",
       "description": "Graphing a static sine wave",
       "image": "sine.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/EIbEYLTaZ"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/EIbEYLTaZ" }
     },
     {
       "title": "Playing With Period",
       "description": "Changing the period of the sine wave graph",
       "image": "period.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/SbRC-G0lU"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/SbRC-G0lU" }
     },
     {
       "title": "Graphing Wave",
       "description": "Animating a sine wave on the canvas",
       "image": "graph.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/c_S9jiXz-"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/c_S9jiXz-" }
     },
     {
       "title": "Circular Wave Exercise",
       "description": "Generating and animating a circular shape with a wavy edge",
       "image": "circular.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/mOm2Is7ba"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/mOm2Is7ba" }
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2021-02-12"
 }

--- a/content/videos/noc/3-angles/7-additive-waves/index.json
+++ b/content/videos/noc/3-angles/7-additive-waves/index.json
@@ -11,9 +11,7 @@
       "title": "Additive Waves",
       "description": "Using a Wave class to trace a moving additive wave with ellipses",
       "image": "add.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/qcRsZ_O5a"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/qcRsZ_O5a" }
     }
   ],
   "groupLinks": [
@@ -29,13 +27,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2021-02-16"
 }

--- a/content/videos/noc/4-particles/1-particle-system/index.json
+++ b/content/videos/noc/4-particles/1-particle-system/index.json
@@ -11,9 +11,7 @@
       "title": "Particle System Simulation",
       "description": "Simulating a particle system with gravity and a single emitter",
       "image": "particle.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/QRzgzQLnQ"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/QRzgzQLnQ" }
     }
   ],
   "groupLinks": [
@@ -64,13 +62,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2021-03-09"
 }

--- a/content/videos/noc/4-particles/2-particle-emitters/index.json
+++ b/content/videos/noc/4-particles/2-particle-emitters/index.json
@@ -11,33 +11,25 @@
       "title": "Particle Emitters",
       "description": "Spawning a new particle emitter on clicking the screen",
       "image": "emitters.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/YqAxA5CYy"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/YqAxA5CYy" }
     },
     {
       "title": "Particle Emitters with Movers Exercise",
       "description": "Adding fire particle effects to an array of movers",
       "image": "movers.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/UXmqwcpRL"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/UXmqwcpRL" }
     },
     {
       "title": "Particles Following Mouse Exercise",
       "description": "Making a particle emitter that follows the mouse",
       "image": "mouse.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/1zTN6PYJg"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/1zTN6PYJg" }
     },
     {
       "title": "Particle Emitters Color Exercise",
       "description": "Clicking on the screen to make a new emitter with a random color",
       "image": "color.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/IYisp9xmJ"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/IYisp9xmJ" }
     }
   ],
   "groupLinks": [
@@ -68,13 +60,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2021-03-12"
 }

--- a/content/videos/noc/4-particles/3-particle-inheritance/index.json
+++ b/content/videos/noc/4-particles/3-particle-inheritance/index.json
@@ -11,9 +11,7 @@
       "title": "Particle System Inheritance",
       "description": "Creating a confetti class that inherits methods from a parent emitter class",
       "image": "inheritance.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/vYgv7Xagg"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/vYgv7Xagg" }
     }
   ],
   "groupLinks": [
@@ -34,13 +32,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2021-04-01"
 }

--- a/content/videos/noc/4-particles/4-particle-textures/index.json
+++ b/content/videos/noc/4-particles/4-particle-textures/index.json
@@ -11,25 +11,19 @@
       "title": "Texture Maker",
       "description": "Generating a new texture using p5.js",
       "image": "image.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/NS4rB1Yx-"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/NS4rB1Yx-" }
     },
     {
       "title": "Image Texture",
       "description": "Importing an external image as a texture in p5.js",
       "image": "texture.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/TTVoNt58T"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/TTVoNt58T" }
     },
     {
       "title": "Shader (WebGL)",
       "description": "Using WebGL vertex and fragment shaders in p5.js",
       "image": "shader.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/EXZmcc4m_"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/EXZmcc4m_" }
     }
   ],
   "groupLinks": [
@@ -50,13 +44,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2021-04-13"
 }

--- a/content/videos/noc/5-autonomous-agents/1-steering-agents/index.json
+++ b/content/videos/noc/5-autonomous-agents/1-steering-agents/index.json
@@ -43,13 +43,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2021-06-04"
 }

--- a/content/videos/noc/5-autonomous-agents/2-seeking-a-target/index.json
+++ b/content/videos/noc/5-autonomous-agents/2-seeking-a-target/index.json
@@ -11,33 +11,25 @@
       "title": "Seek",
       "description": "Creating an agent that moves towards the mouse",
       "image": "seek.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/AxuChwlgb"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/AxuChwlgb" }
     },
     {
       "title": "Seek With Sliders (Exercise)",
       "description": "Using sliders to change the maximum speed and force of the seeking agent",
       "image": "sliders.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/DROTtSI7J"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/DROTtSI7J" }
     },
     {
       "title": "Arrive (Exercise)",
       "description": "A seeking agent that resets when it reaches its target",
       "image": "arrive.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/dQx9oOfTN"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/dQx9oOfTN" }
     },
     {
       "title": "Pursue (Exercise)",
       "description": "A seeking agent that follows a moving target then respawns",
       "image": "pursue.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/XbsgoU_of"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/XbsgoU_of" }
     }
   ],
   "groupLinks": [
@@ -68,13 +60,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2021-06-16"
 }

--- a/content/videos/noc/5-autonomous-agents/3-pursue-and-evade/index.json
+++ b/content/videos/noc/5-autonomous-agents/3-pursue-and-evade/index.json
@@ -11,49 +11,37 @@
       "title": "Flee",
       "description": "Creating an agent that avoids the mouse",
       "image": "flee.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/v-VoQtETO"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/v-VoQtETO" }
     },
     {
       "title": "Pursue",
       "description": "Adding a mover target for the pursuer to chase",
       "image": "pursue.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/Lx3PJMq4m"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/Lx3PJMq4m" }
     },
     {
       "title": "Evade",
       "description": "Creating an agent that avoids a mover object",
       "image": "evade.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/X3ph02Byx"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/X3ph02Byx" }
     },
     {
       "title": "Pursue Boucing Ball",
       "description": "Pursuing a ball that bounces off the edge of the canvas",
       "image": "bounce.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/itlyDq3ZB"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/itlyDq3ZB" }
     },
     {
       "title": "Pursue Wander",
       "description": "Using the wander behavior to steer the mover object",
       "image": "wander.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/EEnmY04lt"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/EEnmY04lt" }
     },
     {
       "title": "Pursue Slider Prediction",
       "description": "Adding a slider to control the mover object's behavior",
       "image": "slider.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/l7MgPpTUB"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/l7MgPpTUB" }
     }
   ],
   "groupLinks": [
@@ -79,13 +67,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2021-06-24"
 }

--- a/content/videos/noc/5-autonomous-agents/4-arrive-steering/index.json
+++ b/content/videos/noc/5-autonomous-agents/4-arrive-steering/index.json
@@ -11,9 +11,7 @@
       "title": "Arrive",
       "description": "Using the arrive steering method to code an agent that arrives at the mouse's position",
       "image": "arrive.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/1eUnUQnwB"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/1eUnUQnwB" }
     }
   ],
   "groupLinks": [
@@ -29,13 +27,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2021-07-12"
 }

--- a/content/videos/noc/5-autonomous-agents/5-wander/index.json
+++ b/content/videos/noc/5-autonomous-agents/5-wander/index.json
@@ -11,49 +11,37 @@
       "title": "Main",
       "description": "Using the wander steering behavior to move an vehicle",
       "image": "wander.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/LVtVlS52Q"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/LVtVlS52Q" }
     },
     {
       "title": "With Sliders",
       "description": "Adding sliders to adjust the wander steering behavior",
       "image": "sliders.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/uxemh7FGc"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/uxemh7FGc" }
     },
     {
       "title": "Deleting Positions",
       "description": "Using an array to draw a trail behind the vehicle, then removing stored positions over time",
       "image": "delete.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/EWHjy--Os"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/EWHjy--Os" }
     },
     {
       "title": "3D",
       "description": "Implementing the wander steering behavior in 3D",
       "image": "three.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/t6sFXmVrk"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/t6sFXmVrk" }
     },
     {
       "title": "Displacement (From Paper)",
       "description": "Using the displacement variation of the wander behavior described in Reynolds' paper",
       "image": "displacement.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/VdHUvgHkm"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/VdHUvgHkm" }
     },
     {
       "title": "Perlin Noise",
       "description": "Using Perin Noise to determine the wander steering angle",
       "image": "perlin.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/XH2DtikuI"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/XH2DtikuI" }
     }
   ],
   "groupLinks": [
@@ -79,13 +67,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2021-09-16"
 }

--- a/content/videos/noc/5-autonomous-agents/6-scalar-projection/index.json
+++ b/content/videos/noc/5-autonomous-agents/6-scalar-projection/index.json
@@ -11,17 +11,13 @@
       "title": "Angle Between",
       "description": "Calculating the angle between the mouse and a line on the canvas",
       "image": "angle.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/ORP5Yx7JX"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/ORP5Yx7JX" }
     },
     {
       "title": "Scalar Projection",
       "description": "Projecting a point under the mouse onto a line",
       "image": "projection.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/c4jmHLFQI"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/c4jmHLFQI" }
     }
   ],
   "groupLinks": [
@@ -72,13 +68,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2021-10-13"
 }

--- a/content/videos/noc/5-autonomous-agents/7-path-following/index.json
+++ b/content/videos/noc/5-autonomous-agents/7-path-following/index.json
@@ -11,17 +11,13 @@
       "title": "Path Following",
       "description": "Making a vehicle follow a path projected from the position of the mosue",
       "image": "path.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/dqM054vBV"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/dqM054vBV" }
     },
     {
       "title": "Complex Path",
       "description": "Generating an array of vehicles that follow a loop",
       "image": "complex.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/2FFzvxwVt"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/2FFzvxwVt" }
     }
   ],
   "groupLinks": [
@@ -47,13 +43,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2021-10-16"
 }

--- a/content/videos/noc/p5-js-web-editor/index.json
+++ b/content/videos/noc/p5-js-web-editor/index.json
@@ -7,13 +7,8 @@
   "timestamps": [],
   "canContribute": true,
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2018-09-06"
 }

--- a/content/videos/noc/perlin/graphing-1d-perlin-noise/index.json
+++ b/content/videos/noc/perlin/graphing-1d-perlin-noise/index.json
@@ -11,25 +11,19 @@
       "title": "Adding Y-axis",
       "description": "Using 1D perlin noise to generate two coordinates",
       "image": "perlin.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/nCYG2SCNq"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/nCYG2SCNq" }
     },
     {
       "title": "Noise Graph",
       "description": "Graphing 1D perlin noise",
       "image": "noise.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/EZeHXBhei"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/EZeHXBhei" }
     },
     {
       "title": "Noisy Sine",
       "description": "Using 1D perlin noise to create a noisy sine wave",
       "image": "sine.jpg",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/M_kuAXwV2"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/M_kuAXwV2" }
     }
   ],
   "groupLinks": [
@@ -50,13 +44,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2016-06-24"
 }

--- a/content/videos/noc/perlin/intro-to-perlin-noise/index.json
+++ b/content/videos/noc/perlin/intro-to-perlin-noise/index.json
@@ -19,13 +19,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2016-06-23"
 }

--- a/content/videos/noc/perlin/noise-vs-random/index.json
+++ b/content/videos/noc/perlin/noise-vs-random/index.json
@@ -11,9 +11,7 @@
       "title": "Noise vs Random",
       "description": "Demonstration of smoothness of noise() and random().",
       "image": "",
-      "urls": {
-        "p5": "https://editor.p5js.org/codingtrain/sketches/u6Te_XMF5"
-      }
+      "urls": { "p5": "https://editor.p5js.org/codingtrain/sketches/u6Te_XMF5" }
     }
   ],
   "groupLinks": [
@@ -34,13 +32,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2016-06-23"
 }

--- a/content/videos/noc/welcome/nature-of-code-2-introduction/index.json
+++ b/content/videos/noc/welcome/nature-of-code-2-introduction/index.json
@@ -17,13 +17,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2020-03-06"
 }

--- a/content/videos/noc/welcome/welcome-to-the-nature-of-code-in-2020-p5js/index.json
+++ b/content/videos/noc/welcome/welcome-to-the-nature-of-code-in-2020-p5js/index.json
@@ -28,13 +28,8 @@
     }
   ],
   "credits": [
-    {
-      "title": "Editing",
-      "name": "Mathieu Blanchette"
-    },
-    {
-      "title": "Animations",
-      "name": "Jason Heglund"
-    }
-  ]
+    { "title": "Editing", "name": "Mathieu Blanchette" },
+    { "title": "Animations", "name": "Jason Heglund" }
+  ],
+  "date": "2020-03-06"
 }


### PR DESCRIPTION
While working on fixes to #638, I realized that some videos did not have dates (~68 of them). I wrote a little scraper to populate them with YouTube's published dates.

Then, I thought I could just run this on all videos to do a little content QA. It caught a few things, notably a bad videoId from the ml5 track.

Sorry for the sometimes larger diffs than required diffs, it seems like the JSON content files were not formatted using Prettier before.