### PR TITLE
remove `jest-extended`

### DIFF
--- a/content-testing/files.test.js
+++ b/content-testing/files.test.js
@@ -18,10 +18,9 @@ const compareFilePresence = (dir, reference, folder) => {
   if (testLocally && reference.isFileSensitive) {
     for (let file in folder.files) {
       test(`Should this file be here: ${folder.files[file].path}`, () =>
-        expect(file).toBeOneOf([
-          ...Object.keys(reference.files),
-          ...fileExceptions
-        ]));
+        expect([...Object.keys(reference.files), ...fileExceptions]).toContain(
+          file
+        ));
     }
   }
   if (testLocally) {
@@ -41,7 +40,7 @@ const compareFilePresence = (dir, reference, folder) => {
             folder.files[file] !== undefined ||
               folder.files[reference.files[file].requiredAlternative] !==
                 undefined
-          ).toBeTrue());
+          ).toEqual(true));
     }
   }
   if (testLocally) {

--- a/content-testing/folders.test.js
+++ b/content-testing/folders.test.js
@@ -20,7 +20,7 @@ const compareFolderStructure = (dir, reference, folder) => {
   if (testLocally && reference.isFolderSensitive) {
     for (let subfolder in folder.folders) {
       test(`Should this folder be here: ${folder.folders[subfolder].path}`, () =>
-        expect(subfolder).toBeOneOf(Object.keys(reference.folders)));
+        expect(Object.keys(reference.folders)).toContain(subfolder));
     }
   }
   if (testLocally) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
       "devDependencies": {
         "glob": "^8.0.3",
         "jest": "^29.3.1",
-        "jest-extended": "^3.2.0",
         "lodash": "^4.17.21",
         "prettier": "^2.8.0",
         "sharp": "^0.31.3",
@@ -13883,27 +13882,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-extended": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-3.2.0.tgz",
-      "integrity": "sha512-jy+1nwlPLPPR6O8O9Mn+BWCBq/jL/9OgdKEG8ekOSQoLyVvAO5nND8ll3UxoajzBu4kYyn7zUKYWRdnTfQPcVw==",
-      "dev": true,
-      "dependencies": {
-        "jest-diff": "^29.0.0",
-        "jest-get-type": "^29.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "jest": ">=27.2.5"
-      },
-      "peerDependenciesMeta": {
-        "jest": {
-          "optional": true
-        }
       }
     },
     "node_modules/jest-get-type": {
@@ -34131,16 +34109,6 @@
         "@types/node": "*",
         "jest-mock": "^29.3.1",
         "jest-util": "^29.3.1"
-      }
-    },
-    "jest-extended": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-3.2.0.tgz",
-      "integrity": "sha512-jy+1nwlPLPPR6O8O9Mn+BWCBq/jL/9OgdKEG8ekOSQoLyVvAO5nND8ll3UxoajzBu4kYyn7zUKYWRdnTfQPcVw==",
-      "dev": true,
-      "requires": {
-        "jest-diff": "^29.0.0",
-        "jest-get-type": "^29.0.0"
       }
     },
     "jest-get-type": {

--- a/package.json
+++ b/package.json
@@ -55,17 +55,10 @@
   "devDependencies": {
     "glob": "^8.0.3",
     "jest": "^29.3.1",
-    "jest-extended": "^3.2.0",
     "lodash": "^4.17.21",
     "prettier": "^2.8.0",
     "sharp": "^0.31.3",
     "slugify": "^1.6.5",
     "svgo": "^3.0.2"
-  },
-  "jest": {
-    "bail": 0,
-    "setupFilesAfterEnv": [
-      "jest-extended/all"
-    ]
   }
 }


### PR DESCRIPTION
In my opinion, this dependency is not bringing enough value to justify its use in the project. The few tests that were using extended `expect()` methods were easily rewritten with core ones.

`"bail": 0` in `package.json` could also be removed since it's already the default https://jestjs.io/docs/configuration#bail-number--boolean