### PR TITLE
yt-desc: Improved Track Parsing and more

### DIFF
--- a/node-scripts/yt-description.mjs
+++ b/node-scripts/yt-description.mjs
@@ -36,59 +36,85 @@ function parseTrack(track) {
   const content = fs.readFileSync(`./${track}`, 'utf-8');
   const parsed = JSON.parse(content);
 
-  let trackFolder, videoList;
+  let trackFolder, videoList, videoDirs;
   if (parsed.chapters) {
     // Main Track
-    let video = parsed.chapters[0].videos[0];
-    trackFolder = video.split('/').slice(0, -2);
+    videoDirs = parsed.chapters
+      .map((chap) =>
+        chap.videos.map((video) => video.split('/').slice(0, -1).join('/'))
+      )
+      .flat()
+      .filter((dir) => dir !== 'challenges');
 
     videoList = parsed.chapters.map((chap) => chap.videos).flat();
   } else {
     // Side Track
-    let video = parsed.videos[0];
-    trackFolder = video.split('/').slice(0, -1);
-
-    // ignore track with coding challenge videos
-    // TODO fix (only checking first video)
-    if (trackFolder[0] === 'challenges') return null;
+    videoDirs = parsed.videos
+      .map((video) => video.split('/').slice(0, -1).join('/'))
+      .filter((dir) => dir !== 'challenges');
 
     videoList = parsed.videos;
   }
 
+  if (videoDirs.length == 0) {
+    // ignore tracks with only challenges
+    return null;
+  } else if (videoDirs.length == 1) {
+    trackFolder = videoDirs[0];
+  } else {
+    // find max used directory
+    trackFolder = findMaxOccurences(videoDirs);
+  }
+
   return {
     trackName,
-    trackFolder: trackFolder.join('/'),
+    trackFolder,
     videoList,
     data: parsed
   };
 }
 
 /**
- * Parses index.json and pushes to videos array
- *
- * Note: has side effects, must be called only once per file
+ * Parses index.json and returns an array
  * @param {string} file File to parse
  */
 function getVideoData(file) {
+  const videoList = [];
   const content = fs.readFileSync(`./${file}`, 'utf-8');
   const video = JSON.parse(content);
 
   const filePath = file.split(path.sep).slice(2);
+  const videoPath = filePath.slice(0, -1).join('/');
   // console.log('[Parsing File]:', filePath.join('/'));
-  let url;
+  let url, canonicalTrack;
 
   if (filePath[0] === 'challenges') {
-    url = filePath.slice(0, 2);
+    url = filePath.slice(0, 2).join('/');
   } else {
-    for (let track of allTracks) {
-      if (filePath.join('/').includes(track.trackFolder)) {
-        url = ['tracks', track.trackName, ...filePath.slice(0, -1)];
-        break;
+    if (video.canonicalTrack) {
+      canonicalTrack = video.canonicalTrack;
+      url = ['tracks', video.canonicalTrack, videoPath].join('/');
+    } else {
+      for (let track of allTracks) {
+        if (track.videoList.includes(videoPath)) {
+          canonicalTrack = track.trackName;
+          url = ['tracks', track.trackName, videoPath].join('/');
+          break;
+        }
       }
     }
   }
 
-  const slug = url[url.length - 1];
+  if (!url) {
+    console.log(
+      '⚠️  Warning: Could not find this video: ' +
+        videoPath +
+        ' in any track or challenge!'
+    );
+    return [];
+  }
+
+  const slug = url.split('/').at(-1);
 
   if (!url || url.length == 0) {
     throw new Error(
@@ -113,24 +139,27 @@ function getVideoData(file) {
       partInfo.title = video.title + ' - ' + part.title;
 
       const videoData = {
-        pageURL: url.join('/'),
+        pageURL: url,
         data: partInfo,
         filePath: file,
         isMultipartChallenge: true,
+        canonicalTrack,
         slug: slug
       };
-      videos.push(videoData);
+      videoList.push(videoData);
     }
   } else {
     video.challengeTitle = video.title;
     const videoData = {
-      pageURL: url.join('/'),
+      pageURL: url,
       data: video,
       filePath: file,
+      canonicalTrack,
       slug: slug
     };
-    videos.push(videoData);
+    videoList.push(videoData);
   }
+  return videoList;
 }
 
 /**
@@ -153,12 +182,13 @@ function primeDirectory(dir) {
   });
 }
 
+const playlistWarnings = new Set();
 /**
  * Retrieves YouTube video/playlist url from relative website path
  * @param {string} url original relative url
  * @returns {string} resolved url
  */
-function resolveYTLink(url) {
+function resolveCTLink(url) {
   if (/https?:\/\/.*/.test(url)) return url;
 
   const location = url.startsWith('/') ? url.substring(1, url.length) : url;
@@ -175,7 +205,13 @@ function resolveYTLink(url) {
       const playlistId = track.data.playlistId;
       return `https://www.youtube.com/playlist?list=${playlistId}`;
     } else {
-      console.warn('Warning: YT Playlist not found for track:', urlchunks[1]);
+      if (!playlistWarnings.has(urlchunks[1])) {
+        console.warn(
+          '⚠️  Warning: YT Playlist not found for track:',
+          urlchunks[1]
+        );
+        playlistWarnings.add(urlchunks[1]);
+      }
       return `https://thecodingtrain.com/${location}`;
     }
   }
@@ -184,11 +220,30 @@ function resolveYTLink(url) {
   try {
     page = videos.find((vid) => vid.pageURL === location).data;
   } catch (err) {
-    console.warn('Warning: Could not resolve to YT video:', url);
+    console.warn('⚠️  Warning: Could not resolve to YT video:', url);
     return `https://thecodingtrain.com${url}`;
   }
 
   return `https://youtu.be/${page.videoId}`;
+}
+
+/**
+ * Finds the most occuring item in an array
+ * @param {string[]} arr array of items
+ */
+function findMaxOccurences(arr) {
+  const counts = {};
+  for (const item of arr) {
+    if (counts[item]) {
+      counts[item]++;
+    } else {
+      counts[item] = 1;
+    }
+  }
+  const max = Object.keys(counts).reduce((a, b) =>
+    counts[a] > counts[b] ? a : b
+  );
+  return max;
 }
 
 /**
@@ -268,25 +323,23 @@ function writeDescription(video) {
     const i = +video.data.videoNumber;
     const previousVideo = videos.find((vid) => vid.data.videoNumber == i - 1);
     const nextVideo = videos.find((vid) => vid.data.videoNumber == i + 1);
+    const challengePL = 'PLRqwX-V7Uu6ZiZxtDDRCi6uhfTH4FilpH';
 
     description += '\n';
 
     if (previousVideo)
-      description += `🎥 Previous video: https://youtu.be/${previousVideo.data.videoId}?list=PLRqwX-V7Uu6ZiZxtDDRCi6uhfTH4FilpH\n`;
+      description += `🎥 Previous video: https://youtu.be/${previousVideo.data.videoId}?list=${challengePL}\n`;
 
     if (nextVideo)
-      description += `🎥 Next video: https://youtu.be/${nextVideo.data.videoId}?list=PLRqwX-V7Uu6ZiZxtDDRCi6uhfTH4FilpH\n`;
-    description +=
-      '🎥 All videos: https://www.youtube.com/playlist?list=PLRqwX-V7Uu6ZiZxtDDRCi6uhfTH4FilpH\n';
+      description += `🎥 Next video: https://youtu.be/${nextVideo.data.videoId}?list=${challengePL}\n`;
+    description += `🎥 All videos: https://www.youtube.com/playlist?list=${challengePL}\n`;
   } else {
     const path = video.pageURL.split('/');
     const videoDir = path.slice(2).join('/');
-    // Find playlist id from main track only
-    // TODO: check in side tracks as well
-    const track = mainTracks.find((track) =>
-      track.videoList.includes(videoDir)
-    );
-    if (track && track.data.playlistId) {
+
+    const track = allTracks.find((t) => t.trackName === video.canonicalTrack);
+
+    if (track) {
       description += '\n';
       let id = track.videoList.indexOf(videoDir);
 
@@ -299,14 +352,18 @@ function writeDescription(video) {
       const nextVideo = videos.find(
         (vid) => vid.pageURL == 'tracks/' + track.trackName + '/' + nextPath
       );
+      const plId = track.data.playlistId
+        ? `?list=${track.data.playlistId}`
+        : '';
 
       if (previousVideo)
-        description += `🎥 Previous video: https://youtu.be/${previousVideo.data.videoId}?list=${track.data.playlistId}\n`;
+        description += `🎥 Previous video: https://youtu.be/${previousVideo.data.videoId}${plId}\n`;
 
       if (nextVideo)
-        description += `🎥 Next video: https://youtu.be/${nextVideo.data.videoId}?list=${track.data.playlistId}\n`;
+        description += `🎥 Next video: https://youtu.be/${nextVideo.data.videoId}${plId}\n`;
 
-      description += `🎥 All videos: https://www.youtube.com/playlist?list=${track.data.playlistId}\n`;
+      if (track.data.playlistId)
+        description += `🎥 All videos: https://www.youtube.com/playlist${plId}\n`;
     }
   }
 
@@ -324,7 +381,7 @@ function writeDescription(video) {
         } else {
           // assume relative link in thecodingtrain.com
           // try to get YT link instead of website link
-          description += `${link.icon} ${link.title}: ${resolveYTLink(url)}\n`;
+          description += `${link.icon} ${link.title}: ${resolveCTLink(url)}\n`;
         }
       }
     }
@@ -342,7 +399,7 @@ function writeDescription(video) {
         const { videoNumber, challengeTitle } = challengeData.data;
         const url = challengeData.pageURL;
         description +=
-          `🚂 ${videoNumber} ${challengeTitle}: ${resolveYTLink(url)}` + '\n';
+          `🚂 ${videoNumber} ${challengeTitle}: ${resolveCTLink(url)}` + '\n';
       } else {
         console.log(`Challenge ${challenge} not found`);
       }
@@ -430,7 +487,7 @@ const allTracks = [...mainTracks, ...sideTracks];
   primeDirectory('./_descriptions');
 
   for (const file of files) {
-    getVideoData(file);
+    videos.push(...getVideoData(file));
   }
 
   if (video) {
@@ -447,6 +504,11 @@ const allTracks = [...mainTracks, ...sideTracks];
       if (!filePath.endsWith('index.json')) filePath = filePath + '/index.json';
       filePath = path.normalize(filePath);
       specifiedVideos = videos.filter((data) => data.filePath === filePath);
+    }
+
+    if (specifiedVideos.length === 0) {
+      console.log(`❌ No video found for ${video}`);
+      return;
     }
 
     for (const video of specifiedVideos) {

--- a/node-scripts/yt-description.mjs
+++ b/node-scripts/yt-description.mjs
@@ -328,11 +328,11 @@ function writeDescription(video) {
     description += '\n';
 
     if (previousVideo)
-      description += `🎥 Previous video: https://youtu.be/${previousVideo.data.videoId}?list=${challengePL}\n`;
+      description += `🎥 Previous: https://youtu.be/${previousVideo.data.videoId}?list=${challengePL}\n`;
 
     if (nextVideo)
-      description += `🎥 Next video: https://youtu.be/${nextVideo.data.videoId}?list=${challengePL}\n`;
-    description += `🎥 All videos: https://www.youtube.com/playlist?list=${challengePL}\n`;
+      description += `🎥 Next: https://youtu.be/${nextVideo.data.videoId}?list=${challengePL}\n`;
+    description += `🎥 All: https://www.youtube.com/playlist?list=${challengePL}\n`;
   } else {
     const path = video.pageURL.split('/');
     const videoDir = path.slice(2).join('/');
@@ -357,13 +357,13 @@ function writeDescription(video) {
         : '';
 
       if (previousVideo)
-        description += `🎥 Previous video: https://youtu.be/${previousVideo.data.videoId}${plId}\n`;
+        description += `🎥 Previous: https://youtu.be/${previousVideo.data.videoId}${plId}\n`;
 
       if (nextVideo)
-        description += `🎥 Next video: https://youtu.be/${nextVideo.data.videoId}${plId}\n`;
+        description += `🎥 Next: https://youtu.be/${nextVideo.data.videoId}${plId}\n`;
 
       if (track.data.playlistId)
-        description += `🎥 All videos: https://www.youtube.com/playlist${plId}\n`;
+        description += `🎥 All: https://www.youtube.com/playlist${plId}\n`;
     }
   }
 

--- a/node-scripts/yt-description.mjs
+++ b/node-scripts/yt-description.mjs
@@ -501,9 +501,9 @@ const allTracks = [...mainTracks, ...sideTracks];
     } catch (e) {
       // local index.json path
       let filePath = video;
-      if (!filePath.endsWith('index.json')) filePath = filePath + '/index.json';
-      filePath = path.normalize(filePath);
-      specifiedVideos = videos.filter((data) => data.filePath === filePath);
+      specifiedVideos = videos.filter((data) =>
+        data.filePath.startsWith(filePath)
+      );
     }
 
     if (specifiedVideos.length === 0) {
@@ -513,9 +513,11 @@ const allTracks = [...mainTracks, ...sideTracks];
 
     for (const video of specifiedVideos) {
       const description = writeDescription(video);
-      console.log('=====================================================');
-      console.log(description);
-      console.log('=====================================================');
+      if (specifiedVideos.length == 1) {
+        console.log('=====================================================');
+        console.log(description);
+        console.log('=====================================================');
+      }
 
       if (copyToClipboard) {
         try {


### PR DESCRIPTION
# yt-desc: Improvements and features

## A. Previous Video / New Video / All Videos

### Current Behaviour
This section is only shown if: 
- it is a video from a main track, which contains a `playlistId` field.
- or challenges

### New Behaviour
This section will be shown for **all videos**. (❗Is this reasonable? Should the default be something else?)
- If the video is a challenge, no change in behaviour
- If the video is from a track which does not have a `playlistId` field, then only `Previous Video` / `Next Video` will be shown (wherever applicable), and not `All Videos`.
- If a video is in multiple tracks, then its `canonicalTrack` will be used.

## B. Path resolution

Now it is possible to give any file path chunk in the generator, and it will know to read all `index.json` files inside the provided directory.
```bash
npm run yt-desc content/videos/transformations/
# same as
# npm run yt-desc content/videos/transformations/translate-rotate-push-pop/index.json
# npm run yt-desc content/videos/transformations/scale/index.json
# npm run yt-desc content/videos/transformations/more-transformations/index.json
```

## C. Example of changes

If we generate the descriptions for `transformations`, here are the relevant segments:
```
# 1
🎥 Next video: https://youtu.be/pkHZTWOoTLM
```
```
# 2
🎥 Previous video: https://youtu.be/o9sgjuh-CBM
🎥 Next video: https://youtu.be/IVMvq9rd8dA
```
```
# 3
🎥 Previous video: https://youtu.be/pkHZTWOoTLM
```

Notice that there is no `All Videos` property, as the `playlistId` field is not set for this track.

## D. Caveats:

### 1. Inconsistent data

Often, the site data is inconsistent with the data on YouTube. Ex: NOC Playlist
![image](https://user-images.githubusercontent.com/59444569/234685491-26682fd9-800b-43d9-88a5-252fe3c44aca.png)

The YouTube playlist only contains videos upto 5.7. (and chapter 6 videos on the website are also inconsistently named on YouTube from an old playlist). A consequence of this mismatch, is that the description of 5.7 will link to 6.1 (physics libraries) as `Next Video`, although the YouTube playlist ends over there.

Though not too harmful, but important to know about.

### 2. Mixing of tracks

This is somewhat of a more significant caveat:

Let's check out the NOC track once again:

![image](https://user-images.githubusercontent.com/59444569/234686362-edaff8b3-e5de-467f-9015-2f53316a0fe3.png)

Here, the next video after video 3.7 is challenge 159 - Simple Pendulum. On YouTube, the description of 3.7 will link to this challenge, as the `Next Video`. However, this is where the chain breaks due to mixing of tracks - The `Previous Video` and `Next Video` for this challenge would be challenges 158 and 160, not some NOC video!

Obviously, this is completely expected, because it is a challenge video, but the point stands - whenever we are mixing videos of multiple tracks, it creates these "breaks" or "redirections" in the chain of links.
