### PR TITLE
Fix showcases filtering edge case (issue #1029)

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -28,6 +28,7 @@ const {
   createShowcasePages
 } = require('./node-scripts/page-generation');
 const set = require('lodash/set');
+const { toSlug } = require('./node-scripts/utils');
 
 exports.createSchemaCustomization = ({ actions }) =>
   actions.createTypes(schema);
@@ -310,15 +311,15 @@ const filterByTagsResolver = async (
   return entries;
 };
 
-const filterByAuthorResolver = async (args, context) => {
-  const { author, skip, limit } = args;
+const filterByAuthorSlugResolver = async (args, context) => {
+  const { authorSlug, skip, limit } = args;
 
   const query = {};
 
   set(query, 'sort.fields', ['submittedOn', 'title']);
   set(query, 'sort.order', ['DESC', 'ASC']);
 
-  if (author) set(query, `filter.author.name.eq`, author);
+  if (authorSlug) set(query, `filter.author.nameSlug.eq`, authorSlug);
   if (skip) set(query, 'skip', skip);
   if (limit) set(query, 'limit', limit);
 
@@ -434,6 +435,12 @@ exports.createResolvers = ({ createResolvers }) => {
         resolve: contributionSubmittedOnResolver
       }
     },
+    Author: {
+      nameSlug: {
+        type: 'String',
+        resolve: (source) => toSlug(source.name)
+      }
+    },
     Query: {
       tracksPaginatedFilteredByTags: {
         type: ['Track'],
@@ -462,7 +469,7 @@ exports.createResolvers = ({ createResolvers }) => {
       contributionsPaginatedFilteredByTags: {
         type: ['Contribution'],
         resolve: async (source, args, context, info) =>
-          await filterByAuthorResolver(args, context)
+          await filterByAuthorSlugResolver(args, context)
       }
     }
   };

--- a/node-scripts/page-generation.js
+++ b/node-scripts/page-generation.js
@@ -343,16 +343,19 @@ exports.createShowcasePages = async (graphql, createPage) => {
     pathPrefix: '/showcase',
     component: require.resolve(`../src/templates/showcases.js`),
     context: {
-      author: ''
+      author: '',
+      authorSlug: ''
     }
   });
 
   for (let author of [...authors, '']) {
+    const authorSlug = toSlug(author);
+
     const {
       data: { filteredContributions }
     } = await graphql(`
         query {
-          filteredContributions: contributionsPaginatedFilteredByTags(author: "${author}")  {
+          filteredContributions: contributionsPaginatedFilteredByTags(authorSlug: "${authorSlug}")  {
             id
           }
         }
@@ -362,9 +365,9 @@ exports.createShowcasePages = async (graphql, createPage) => {
       createPage,
       items: filteredContributions,
       itemsPerPage: SHOWCASE_ITEMS_PER_PAGE,
-      pathPrefix: `/showcase/author/${!author ? 'all' : toSlug(author)}`,
+      pathPrefix: `/showcase/author/${!author ? 'all' : authorSlug}`,
       component: require.resolve(`../src/templates/showcases.js`),
-      context: { author }
+      context: { author, authorSlug }
     });
   }
 };

--- a/node-scripts/schema.js
+++ b/node-scripts/schema.js
@@ -158,6 +158,9 @@ type CodeUrls implements Node {
 type Author implements Node {
   name: String!
   url: String
+
+  # as resolver
+  nameSlug: String! 
 }
 
 type Chapter implements Node {
@@ -378,6 +381,6 @@ type SupportSection implements Node {
 type Query {
   tracksPaginatedFilteredByTags(language: String, topic: String, skip: Int, limit: Int): [Track]
   challengesPaginatedFilteredByTags(language: String, topic: String, skip: Int, limit: Int): [Challenge]
-  contributionsPaginatedFilteredByTags(author: String, skip: Int, limit: Int): [Contribution]
+  contributionsPaginatedFilteredByTags(authorSlug: String, skip: Int, limit: Int): [Contribution]
 }
 `;

--- a/src/templates/showcases.js
+++ b/src/templates/showcases.js
@@ -69,7 +69,9 @@ const ShowcasePage = ({ data, pageContext, location }) => {
                 />
                 {i % 3 !== 2 && <div className={css.horizontalSpacer}></div>}
                 {i % 3 === 2 && <div className={css.verticalSpacer}></div>}
-                {(i % 3 === 1 && i === contributions.length - 1 ? <div className={css.horizontalSpacerLast}></div> : null)}
+                {i % 3 === 1 && i === contributions.length - 1 ? (
+                  <div className={css.horizontalSpacerLast}></div>
+                ) : null}
               </Fragment>
             ))}
           </div>
@@ -80,7 +82,7 @@ const ShowcasePage = ({ data, pageContext, location }) => {
 };
 
 export const query = graphql`
-  query ($skip: Int, $limit: Int, $author: String!) {
+  query ($skip: Int, $limit: Int, $authorSlug: String!) {
     pageData: allShowcasePageInfo {
       nodes {
         title
@@ -88,7 +90,7 @@ export const query = graphql`
       }
     }
     contributions: contributionsPaginatedFilteredByTags(
-      author: $author
+      authorSlug: $authorSlug
       skip: $skip
       limit: $limit
     ) {


### PR DESCRIPTION
Closes #1029.

This PR adds a new `author.nameSlug` resolver on the `Author` Gatsby node, which is then used by the showcases page to correctly filter by _slugified_ author name.

<img width="1176" alt="Screenshot 2023-05-01 at 12 48 54 PM" src="https://user-images.githubusercontent.com/4009209/235490896-f97a0229-a613-420a-8bdb-36900db97e63.png">
