### PR TITLE
Minor tags UX improvements

### DIFF
--- a/src/components/Tags.js
+++ b/src/components/Tags.js
@@ -13,12 +13,12 @@ const Tags = memo(
     linkTo,
     headerType = 'h2'
   }) => {
-    const [showAll, setShowAll] = useState(false);
-    const truncatedSize = 2;
-    const overflowSize = items.length - truncatedSize;
-    const allowToggle = overflowSize > 1;
+    const [truncate, setTruncate] = useState(true);
+    const truncateSize = 2;
+    const overflowSize = items.length - truncateSize;
+    const showToggle = overflowSize > 1;
     const visibleItems =
-      !allowToggle || showAll ? items : items.slice(0, truncatedSize);
+      showToggle && truncate ? items.slice(0, truncateSize) : items;
 
     const Header = headerType;
 
@@ -26,6 +26,7 @@ const Tags = memo(
       <div
         className={cn(css.root, className, { [css.singleLine]: singleLine })}>
         <Header className={css.tagHeading}>{heading}</Header>
+
         {visibleItems.map((tag, index) =>
           linkTo ? (
             <Link
@@ -34,21 +35,21 @@ const Tags = memo(
               to={linkTo(tag)}
               state={{ expanded: true }}>
               {tag}
-              {index !== visibleItems.length - 1 && ','}
+              {index !== items.length - 1 && ','}
             </Link>
           ) : (
             <span className={css.tag} key={tag}>
               {tag}
-              {index !== visibleItems.length - 1 && ','}
+              {index !== items.length - 1 && ','}
             </span>
           )
         )}
 
-        {allowToggle && (
+        {showToggle && (
           <button
             className={css.showButton}
-            onClick={() => setShowAll((v) => !v)}>
-            Show {showAll ? 'less' : `${overflowSize} more`}
+            onClick={() => setTruncate((v) => !v)}>
+            {truncate ? `and ${overflowSize} more` : 'show less'}
           </button>
         )}
       </div>

--- a/src/components/Tags.js
+++ b/src/components/Tags.js
@@ -14,8 +14,12 @@ const Tags = memo(
     headerType = 'h2'
   }) => {
     const [showAll, setShowAll] = useState(false);
-    const allowToggle = items.length > 3;
-    const visibleItems = !allowToggle || showAll ? items : items.slice(0, 2);
+    const truncatedSize = 2;
+    const overflowSize = items.length - truncatedSize;
+    const allowToggle = overflowSize > 1;
+    const visibleItems =
+      !allowToggle || showAll ? items : items.slice(0, truncatedSize);
+
     const Header = headerType;
 
     return (
@@ -30,12 +34,12 @@ const Tags = memo(
               to={linkTo(tag)}
               state={{ expanded: true }}>
               {tag}
-              {index !== items.length - 1 && ','}
+              {index !== visibleItems.length - 1 && ','}
             </Link>
           ) : (
             <span className={css.tag} key={tag}>
               {tag}
-              {index !== items.length - 1 && ','}
+              {index !== visibleItems.length - 1 && ','}
             </span>
           )
         )}
@@ -44,7 +48,7 @@ const Tags = memo(
           <button
             className={css.showButton}
             onClick={() => setShowAll((v) => !v)}>
-            Show {showAll ? 'less' : 'more'}
+            Show {showAll ? 'less' : `${overflowSize} more`}
           </button>
         )}
       </div>

--- a/src/components/Tags.js
+++ b/src/components/Tags.js
@@ -14,8 +14,10 @@ const Tags = memo(
     headerType = 'h2'
   }) => {
     const [showAll, setShowAll] = useState(false);
-    const visibleItems = showAll ? items : items.slice(0, 2);
+    const allowToggle = items.length > 3;
+    const visibleItems = !allowToggle || showAll ? items : items.slice(0, 2);
     const Header = headerType;
+
     return (
       <div
         className={cn(css.root, className, { [css.singleLine]: singleLine })}>
@@ -38,7 +40,7 @@ const Tags = memo(
           )
         )}
 
-        {items.length > 2 && !showAll && (
+        {allowToggle && (
           <button
             className={css.showButton}
             onClick={() => setShowAll((v) => !v)}>

--- a/src/components/Tags.module.css
+++ b/src/components/Tags.module.css
@@ -43,4 +43,5 @@
   font-size: inherit;
   text-decoration: underline;
   color: inherit;
+  padding: 0;
 }

--- a/src/components/tracks/Card.module.css
+++ b/src/components/tracks/Card.module.css
@@ -126,6 +126,10 @@
 .tags {
   line-height: var(--baseline-1of3);
   font-size: var(--maru-xsmall);
+
+  & a {
+    margin-right: var(--spacing-xsmall);
+  }
 }
 
 .filterHeading,


### PR DESCRIPTION
While we're fixing tags, here are a few adjustments that I had noted down but never spent the time to implement.

- Fix the expand/collapse toggle behavior. The "show less" option was never properly displaying.

- Don't display "show more" when there's only 1 more tag to show. The button itself takes up the space it would've taken to display the remaining tag.

- Don't show the last trailing comma if we have a "show more" button

- Remove padding on the "show more" button so it aligns better when it's first in a row

- Display the amount of tags to be revealed in the "show more" button

The track `ml5js-beginners-guide` illustrates these changes well:

**Before**
https://thecodingtrain.com/tracks/ml5js-beginners-guide

https://user-images.githubusercontent.com/4009209/236052090-fd163510-5665-4d09-8d35-8f77f17faaa8.mp4


**After**
https://deploy-preview-1043--codingtrain.netlify.app/tracks/ml5js-beginners-guide

https://user-images.githubusercontent.com/4009209/236052095-27cf9946-8ae9-4526-9e61-1cd8875a6ba5.mp4