### PR TITLE
fix Gatsby cache problem related to tracks

### DIFF
--- a/node-scripts/node-generation.js
+++ b/node-scripts/node-generation.js
@@ -195,7 +195,7 @@ exports.createTrackRelatedNode = (
         ),
         internal: {
           type: `Chapter`,
-          contentDigest: createContentDigest(data)
+          contentDigest: createContentDigest(chapter)
         }
       });
       chapters.push(newNode);


### PR DESCRIPTION
The digest for track Chapter nodes was computed using the `data` variable, which previously had its `videos` property removed.

https://github.com/fturmel/thecodingtrain.com/blob/c2d6f21e5b6ebd64e9c7cbca8d75ab4b285ad44c/node-scripts/node-generation.js#L185C10-L203