### PR TITLE
Fix incremental Gatsby builds when an existing cover image changed

### DIFF
--- a/gatsby/onCreateNode.mjs
+++ b/gatsby/onCreateNode.mjs
@@ -337,12 +337,15 @@ const create404PageRelatedNodes = ({ createNode, createNodeId, node }) => {
  * Helper function to create CoverImage node from image file node
  */
 const createCoverImageNodeHelper = (createNode, fileNode, id) => {
-  const newNode = {
-    ...createDefaults('CoverImage', fileNode),
+  const { internal } = createDefaults('CoverImage', fileNode);
 
+  const newNode = {
     id,
-    file: fileNode.id
+    parent: fileNode.id,
+    file: fileNode.id,
+    internal
   };
+
   createNode(newNode);
 };
 


### PR DESCRIPTION
This is something I introduced in #1053 (sorry!).

For some reason, if we copy the `File` node properties when creating a `CoverImage` node, it will cause the `childImageSharp` property to be missing only on incremental builds and when the image source was modified.

You can see how it created a build failure on #1074

We may require a full Gatsby cache clear along with this build so that all `CoverImage` nodes get recreated with the required properties only.