### PR TITLE
Improve content testing errors

### DIFF
--- a/content-testing/format-augmented.test.js
+++ b/content-testing/format-augmented.test.js
@@ -82,7 +82,7 @@ const videoNumberValidator = string().test(
 const timestampRegex = /^(?:[0-4]:)?[0-5]?\d:[0-5]?\d$/;
 const timestampValidator = string().test(
   'timestamps',
-  'A timstamp should be in the `mm:ss` or `h:mm:ss` format',
+  'A timestamp should be in the `mm:ss` or `h:mm:ss` format',
   (value) => {
     if (!value) return true;
     return timestampRegex.test(value);
@@ -271,15 +271,20 @@ const rules = {
 // validate JSON files against schemas
 
 for (const [label, [paths, schema]] of Object.entries(rules)) {
-  describe(label, () => {
-    test.each(paths)('%s', (path) => {
-      const obj = JSON.parse(readFileSync(path));
+  describe.each(paths)(`${label} › %s`, (path) => {
+    const obj = JSON.parse(readFileSync(path));
 
-      try {
-        schema.validateSync(obj, { context: { filepath: path } });
-      } catch (e) {
-        expect([e.message, e.params.originalValue]).toBeUndefined();
+    try {
+      schema.validateSync(obj, {
+        abortEarly: false,
+        context: { filepath: path }
+      });
+    } catch (e) {
+      for (const err of e.inner) {
+        test(err.message, () => {
+          expect(err.params.originalValue).not.toBe(err.params.originalValue);
+        });
       }
-    });
+    }
   });
 }

--- a/content-testing/format-augmented.test.js
+++ b/content-testing/format-augmented.test.js
@@ -288,3 +288,6 @@ for (const [label, [paths, schema]] of Object.entries(rules)) {
     }
   });
 }
+
+// We need to always have at least one test block in a Jest file
+test('', () => {});


### PR DESCRIPTION
By setting the `abortEarly` option to `false` in the `yup` library and restructuring the unit tests a bit, we can show all schema validation failures (not just the first) and display the Jest errors in a more readable way.

**Before**
<img width="585" alt="Screenshot 2023-06-02 at 6 49 53 PM" src="https://github.com/CodingTrain/thecodingtrain.com/assets/4009209/ddd2c812-7da3-4202-8cab-ff49f290ce9b">


**After**
<img width="1015" alt="Screenshot 2023-06-02 at 6 45 00 PM" src="https://github.com/CodingTrain/thecodingtrain.com/assets/4009209/16e02049-60bf-4136-b41e-94efb628c62e">
