### PR TITLE
Refactor ShareButton + minor improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@octokit/core": "^4.2.0",
         "classnames": "^2.3.2",
         "clipboardy": "^3.0.0",
-        "copy-to-clipboard": "^3.3.3",
         "gatsby": "^5.7.0",
         "gatsby-core-utils": "^4.7.0",
         "gatsby-plugin-image": "^3.7.0",
@@ -7710,14 +7709,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
-    },
-    "node_modules/copy-to-clipboard": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
-      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
-      "dependencies": {
-        "toggle-selection": "^1.0.6"
-      }
     },
     "node_modules/core-js": {
       "version": "3.29.0",
@@ -21739,11 +21730,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/toggle-selection": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@octokit/core": "^4.2.0",
     "classnames": "^2.3.2",
     "clipboardy": "^3.0.0",
-    "copy-to-clipboard": "^3.3.3",
     "gatsby": "^5.7.0",
     "gatsby-core-utils": "^4.7.0",
     "gatsby-plugin-image": "^3.7.0",

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'gatsby';
-import classnames from 'classnames';
+import cn from 'classnames';
 import * as css from './Button.module.css';
 
 export const Button = ({
@@ -15,7 +15,7 @@ export const Button = ({
   rainbow,
   ...otherProps
 }) => {
-  const classes = classnames(css.root, className, {
+  const classes = cn(css.root, className, {
     [css[variant]]: css[variant],
     [css.rainbow]: rainbow
   });

--- a/src/components/Question.js
+++ b/src/components/Question.js
@@ -30,11 +30,9 @@ const Question = ({ variant, slug, question, answer, currentHash }) => {
         [css[variant]]: css[variant],
         [css.open]: open
       })}>
-      <div
+      <button
         className={css.summary}
         onClick={() => setOpen(!open)}
-        onKeyPress={(e) => e.key === 'Enter' && setOpen(!open)}
-        role="button"
         tabIndex="0">
         <Open className={cn(css.icon, { [css.rotateIcon]: open })} />
         <h3>{question}</h3>
@@ -46,7 +44,8 @@ const Question = ({ variant, slug, question, answer, currentHash }) => {
             #
           </a>
         )}
-      </div>
+      </button>
+
       {open && (
         <div className={css.answer}>
           {answerMainText}

--- a/src/components/ShareButton.js
+++ b/src/components/ShareButton.js
@@ -1,65 +1,44 @@
-import React, { useState, Children, cloneElement } from 'react';
-import classnames from 'classnames';
+import React, { useState } from 'react';
+import cn from 'classnames';
 
 import Button from './Button';
 
 import * as css from './ShareButton.module.css';
 
-import copy from 'copy-to-clipboard';
-
-const CopyUrlToClipboard = ({ children, text, onCopy, options }) => {
-  const onClick = (event) => {
-    const elem = Children.only(children);
-    const res = copy(window.location.href, options);
-
-    onCopy && onCopy(text, res);
-
-    if (elem && elem.props && typeof elem.props.onClick === 'function') {
-      elem.props.onClick(event);
-    }
-  };
-
-  const elem = Children.only(children);
-
-  return cloneElement(elem, { onClick });
-};
-
-export const ShareButton = ({
-  className,
-  variant,
-  wrapped,
-  text = 'Copy link'
-}) => {
+export const ShareButton = ({ className, variant, wrapped, text }) => {
   const [isCopied, setIsCopied] = useState(false);
 
-  const onCopy = (text, res) => {
-    if (res) {
-      setIsCopied(true);
-      setTimeout(() => {
-        setIsCopied(false);
-      }, 1000);
-    }
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(window.location.href);
+
+    setIsCopied(true);
+    setTimeout(() => {
+      setIsCopied(false);
+    }, 1000);
   };
 
-  const classes = classnames(css.root, className, {
+  const classes = cn(css.root, className, {
     [css[variant]]: css[variant]
   });
 
   return (
-    <CopyUrlToClipboard onCopy={onCopy}>
-      <Button className={classes} aria-label="Copy page URL">
-        <span className={css.linkIcon}>🔗</span>
-        {text && <span>{text}</span>}
-        {isCopied && (
-          <p
-            className={
-              wrapped ? css.copiedNotificationWrapped : css.copiedNotification
-            }>
-            Copied to clipboard!
-          </p>
-        )}
-      </Button>
-    </CopyUrlToClipboard>
+    <Button
+      className={classes}
+      aria-label="Copy page URL"
+      onClick={handleCopy}
+      disabled={isCopied}>
+      <span className={css.linkIcon}>🔗</span>
+      {text && <span>{text}</span>}
+      {isCopied && (
+        <p
+          className={cn(
+            css.copiedNotification,
+            wrapped ? css.copiedNotificationRight : css.copiedNotificationLeft
+          )}>
+          Copied to clipboard!
+        </p>
+      )}
+    </Button>
   );
 };
 

--- a/src/components/ShareButton.module.css
+++ b/src/components/ShareButton.module.css
@@ -4,10 +4,11 @@
   justify-content: center;
   align-items: center;
   border-radius: 0px;
-  height: var(--baseline-box);
+  height: var(--baseline);
   padding: 0 var(--box-padding);
   cursor: pointer;
   line-height: var(--baseline);
+  user-select: none;
 
   & svg {
     stroke: var(--gray-dark);
@@ -30,9 +31,6 @@ span.linkIcon {
   & span {
     font-weight: 600;
   }
-  & svg path {
-    stroke-width: 2px;
-  }
 }
 
 .copiedNotification {
@@ -42,45 +40,26 @@ span.linkIcon {
   margin: 0;
   padding: 0 var(--box-padding);
   top: var(--baseline-1of4);
-  left: calc(-1 * (205px + 2 * var(--box-padding)));
   border-radius: 5px;
   border: var(--border);
-  width: calc((200px + 2 * var(--box-padding)));
+  width: calc(200px + 2 * var(--box-padding));
   line-height: var(--baseline-1of2);
   cursor: auto;
   background-color: var(--gray-light);
   color: var(--gray-dark);
 }
 
-.copiedNotificationWrapped {
-  position: absolute;
-  display: flex;
-  justify-content: center;
-  margin: 0;
-  padding: 0 var(--box-padding);
-  top: var(--baseline-1of4);
-  right: calc(-1 * (205px + 2 * var(--box-padding)));
-  border-radius: 5px;
-  border: var(--border);
-  width: calc((200px + 2 * var(--box-padding)));
-  line-height: var(--baseline-1of2);
-  cursor: auto;
-  background-color: var(--gray-light);
-  color: var(--gray-dark);
+.copiedNotificationLeft {
+  left: calc(-1 * (5px + 200px + 2 * var(--box-padding)));
+}
+
+.copiedNotificationRight {
+  right: calc(-1 * (5px + 200px + 2 * var(--box-padding)));
 }
 
 /* Variants */
 
 .red {
-  & svg {
-    & path {
-      stroke: var(--red);
-    }
-    & path + path {
-      fill: var(--red);
-    }
-  }
-
   & span {
     color: var(--red);
   }
@@ -89,33 +68,14 @@ span.linkIcon {
     border: var(--border-red);
     background-color: var(--red-light);
   }
-
-  & .copiedNotificationWrapped {
-    border: var(--border-red);
-    background-color: var(--red-light);
-  }
 }
 
 .cyan {
-  & svg {
-    & path {
-      stroke: var(--cyan);
-    }
-    & path + path {
-      fill: var(--cyan);
-    }
-  }
-
   & span {
     color: var(--cyan);
   }
 
   & .copiedNotification {
-    border: var(--border-cyan);
-    background-color: var(--cyan-light);
-  }
-
-  & .copiedNotificationWrapped {
     border: var(--border-cyan);
     background-color: var(--cyan-light);
   }

--- a/src/components/Tabs.module.css
+++ b/src/components/Tabs.module.css
@@ -30,9 +30,15 @@
   font-family: var(--maru-mono);
   text-transform: none;
   color: var(--gray-dark);
+  user-select: none;
 }
 
 .tab:hover {
+  font-weight: 600;
+}
+
+.active {
+  cursor: default;
   font-weight: 600;
 }
 

--- a/src/components/challenges/VideoSection.js
+++ b/src/components/challenges/VideoSection.js
@@ -83,21 +83,17 @@ const VideoSection = ({ challenge }) => {
               [css.onlyShare]: timestamps.length === 0
             })}
             variant={variant}
-            text=""
           />
+
           {timestamps.length > 0 && (
-            <div
+            <button
               className={css.timelinesToggle}
               onClick={() => setShowTimeline((v) => !v)}
-              onKeyPress={(e) =>
-                e.key === 'Enter' && setShowTimeline((v) => !v)
-              }
-              role="button"
               tabIndex="0"
               aria-label="Toggle timeline">
               <span className={css.back}>Back</span>
               <span className={css.arrow}> </span>
-            </div>
+            </button>
           )}
         </div>
       </header>

--- a/src/components/challenges/VideoSection.module.css
+++ b/src/components/challenges/VideoSection.module.css
@@ -272,6 +272,7 @@
     transform: rotate(-45deg);
     width: 10px;
     height: 10px;
+    margin-left: -5px;
     border-left: 1.5px solid var(--cyan);
     border-bottom: 1.5px solid var(--cyan);
   }

--- a/src/components/tracks/VideoSection.js
+++ b/src/components/tracks/VideoSection.js
@@ -98,12 +98,11 @@ const VideoSection = ({ track, video, trackPosition, mainTitle }) => {
             headerType="h3"
           />
 
-          <ShareButton className={css.share} variant={variant} text="" />
-          <div
+          <ShareButton className={css.share} variant={variant} />
+
+          <button
             className={css.timelinesToggle}
             onClick={() => setShowTimeline((v) => !v)}
-            onKeyPress={(e) => e.key === 'Enter' && setShowTimeline((v) => !v)}
-            role="button"
             tabIndex="0"
             aria-label="Toggle timeline">
             <span className={css.back}>Back</span>
@@ -111,7 +110,7 @@ const VideoSection = ({ track, video, trackPosition, mainTitle }) => {
             <span className={css.progress}>
               {videoIndex} / {trackTotal}{' '}
             </span>
-          </div>
+          </button>
         </div>
       </header>
       <div className={css.videoPlayer}>

--- a/src/components/tracks/VideoSection.module.css
+++ b/src/components/tracks/VideoSection.module.css
@@ -271,6 +271,7 @@
     transform: rotate(-45deg);
     width: 10px;
     height: 10px;
+    margin-left: -5px;
     border-left: 1.5px solid var(--red);
     border-bottom: 1.5px solid var(--red);
   }


### PR DESCRIPTION
A collection of very minor improvements while poking around the site's share button functionality.

- The `ShareButton` implementation looked odd and convoluted to me. I cleaned it up a bit, removed the `copy-to-clipboard` dependency and just used the native Clipboard API which has been [well supported for some time now](https://caniuse.com/async-clipboard).
- Fixed a "copied" [notification position bug](https://github.com/CodingTrain/thecodingtrain.com/issues/772#issuecomment-1335975436) on page load, and also refactored the `Tabs` component so it's a bit more readable and idiomatic (refs over DOM selector).
- Converted a few divs with `role="button"` into actual buttons so that keyboard events don't have to be re-implemented. `onKeyPress` has been [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event) anyways.
- Standardized import name of the `classnames` package to `cn` everywhere (only two components were different)
- Vertically aligned some grid lines when the share button wraps to the next line:

<img width="1405" alt="image" src="https://github.com/CodingTrain/thecodingtrain.com/assets/4009209/5e58ecfb-b7a2-4a8e-b6e2-f37a783bc429">
