### PR TITLE
Auto-select the track and video submission form fields when possible

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -13,6 +13,7 @@ export const Button = ({
   children,
   disabled,
   rainbow,
+  state,
   ...otherProps
 }) => {
   const classes = cn(css.root, className, {
@@ -21,7 +22,7 @@ export const Button = ({
   });
 
   return to ? (
-    <Link to={to} className={classes}>
+    <Link to={to} className={classes} state={state}>
       {children}
     </Link>
   ) : href ? (

--- a/src/components/ButtonPanel.js
+++ b/src/components/ButtonPanel.js
@@ -12,7 +12,8 @@ const ButtonPanel = ({
   variant,
   className,
   smallWrap,
-  rainbow
+  rainbow,
+  buttonState
 }) => {
   return (
     <div
@@ -23,6 +24,7 @@ const ButtonPanel = ({
       {text && <p>{text}</p>}
       <div className={css.buttonContainer}>
         <Button
+          state={buttonState}
           variant={variant}
           rainbow={rainbow}
           {...{ [buttonLink.startsWith('/') ? 'to' : 'href']: buttonLink }}>

--- a/src/components/PassengerShowcaseForm.js
+++ b/src/components/PassengerShowcaseForm.js
@@ -1,7 +1,10 @@
 import React, { useState, useRef, useMemo } from 'react';
 import { useStaticQuery, graphql } from 'gatsby';
 import { object, string } from 'yup';
+import { useLocation } from '@reach/router';
+
 import Button from './Button';
+
 import * as css from './PassengerShowcaseForm.module.css';
 
 // event.body expected to be:
@@ -120,8 +123,13 @@ const useVideosWithShowcase = function () {
 };
 
 const PassengerShowcaseForm = () => {
+  const location = useLocation();
   const ref = useRef();
-  const [state, setState] = useState(defaultState);
+  const [state, setState] = useState({
+    ...defaultState,
+    track: location.state?.track ?? '',
+    video: location.state?.video ?? ''
+  });
   const [error, setError] = useState(null);
   const [submitted, setSubmitted] = useState(false);
 

--- a/src/components/PassengerShowcasePanel.js
+++ b/src/components/PassengerShowcasePanel.js
@@ -12,7 +12,8 @@ import { shuffleCopy } from '../utils';
 const PassengerShowcasePanel = ({
   contributions,
   placeholderImage,
-  headerType = 'h2'
+  headerType = 'h2',
+  submitButtonState
 }) => {
   // First render : as many empty contributions as there are challenges
   const [shuffledContribs, setShuffledContribs] = useState(() =>
@@ -28,6 +29,7 @@ const PassengerShowcasePanel = ({
       ? 'The Showcase is collection of projects created by viewers like you!'
       : 'No showcase projects submitted yet, you could be the first!';
   const Header = headerType;
+
   return (
     <section className={css.root}>
       <div className={css.titleBox}>
@@ -50,6 +52,7 @@ const PassengerShowcasePanel = ({
         text="Have you made something? Please share your work!"
         buttonText="Submit to the showcase"
         buttonLink="/guides/passenger-showcase-guide"
+        buttonState={submitButtonState}
         variant="purple"
         rainbow
         className={css.showcasePanel}
@@ -70,6 +73,7 @@ const Contribution = ({
     : placeholderImage;
   const url = contribution.url;
   const Header = headerType;
+
   return (
     <article className={css.contrib}>
       <a className={css.title} href={url} target="_blank" rel="noreferrer">

--- a/src/templates/challenge.js
+++ b/src/templates/challenge.js
@@ -67,6 +67,7 @@ const Challenge = ({ data }) => {
       <PassengerShowcasePanel
         contributions={challenge.showcase}
         placeholderImage={contributionsPlaceholder}
+        submitButtonState={{ track: 'challenges', video: challenge.slug }}
       />
 
       {challenge.relatedChallenges.length > 0 && (

--- a/src/templates/track-video.js
+++ b/src/templates/track-video.js
@@ -27,11 +27,13 @@ const Track = ({ pageContext, data }) => {
     videoPlaceHolderImage,
     challengePlaceholderImage
   } = data;
+
   const contributionsPlaceholder = contributionPlaceholderImage
     ? contributionPlaceholderImage.childImageSharp.gatsbyImageData
     : videoPlaceHolderImage
     ? videoPlaceHolderImage.childImageSharp.gatsbyImageData
     : null;
+
   const challengesPlaceholder =
     challengePlaceholderImage.childImageSharp.gatsbyImageData;
 
@@ -105,6 +107,10 @@ const Track = ({ pageContext, data }) => {
             contributions={video.showcase}
             placeholderImage={contributionsPlaceholder}
             headerType={isTrackPage ? 'h3' : 'h2'}
+            submitButtonState={{
+              track: video.canonicalTrack?.slug ?? 'challenges',
+              video: video.slug
+            }}
           />
         </>
       )}
@@ -201,6 +207,9 @@ export const query = graphql`
     video: videoInterface(id: { eq: $videoId }) {
       title
       slug
+      canonicalTrack {
+        slug
+      }
       videoId
       nebulaSlug
       description


### PR DESCRIPTION
Had this idea yesterday, works really well!

We're simply passing a state object using the router when the user clicks on one of the "submit to the showcase" CTAs in a track or challenge. This allows the form to know where the user came from and select the correct `track` and `video` values for them.

https://github.com/CodingTrain/thecodingtrain.com/assets/4009209/01e698cf-22dc-4413-82bc-4cb22ff4c73b
