### PR TITLE
display credits for Track videos

### DIFF
--- a/gatsby/createSchemaCustomization.mjs
+++ b/gatsby/createSchemaCustomization.mjs
@@ -21,6 +21,7 @@ const schema = /* GraphQL */ `
     groupLinks: [GroupLink!]
     source: String!
     nebulaSlug: String
+    credits: [Credit!]!
 
     # as resolver
     showcase: [Contribution]
@@ -46,6 +47,7 @@ const schema = /* GraphQL */ `
     groupLinks: [GroupLink!]
     source: String!
     nebulaSlug: String
+    credits: [Credit!]!
 
     # as resolver
     showcase: [Contribution]
@@ -71,10 +73,17 @@ const schema = /* GraphQL */ `
     groupLinks: [GroupLink!]
     source: String!
     nebulaSlug: String
+    credits: [Credit!]!
 
     # as resolver
     showcase: [Contribution]
     canonicalTrack: Track
+  }
+
+  type Credit {
+    title: String!
+    name: String!
+    url: String
   }
 
   type Contribution implements Node {

--- a/src/templates/track-video.js
+++ b/src/templates/track-video.js
@@ -256,6 +256,11 @@ export const query = graphql`
           description
         }
       }
+      credits {
+        title
+        name
+        url
+      }
       canContribute
       showcase {
         title


### PR DESCRIPTION
@dipamsen pointed out on Discord that the Track videos credits were not being displayed, even though they exist (and are required) in the source JSON files. This should fix the issue.