### PR TITLE
Apple II redirect update

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -31,7 +31,8 @@
 /pi2022 https://editor.p5js.org/codingtrain/full/U11UYbgVc 302!
 /colors https://coding-train-colors.vercel.app/ 302!
 /wheel https://editor.p5js.org/kingpepe/full/n_KhX8lYC 302!
-/appleII /challenges/173-snake-applesoft-basic 302!
+/appleII /tracks/coding-together-apple-ii 302!
+/appleii /tracks/coding-together-apple-ii 302!
 /apple2tree /challenges/174-graphics-applesoft-basic 302!
 /choochoo https://curiositystream.com/?coupon=choochoo 302!
 /tree /challenges/14-fractal-trees-recursive 302!


### PR DESCRIPTION
Minor change and addition (I got a note saying the "redirect" wasn't working).

```
/appleii -> /tracks/coding-together-apple-ii
/appleII -> /tracks/coding-together-apple-ii
```
