### PR TITLE
Add corrections + enhancement for yt-desc

### DIFF
--- a/content-testing/schemas.js
+++ b/content-testing/schemas.js
@@ -13,6 +13,7 @@ const {
   youtubePlaylistIdValidator,
   videoNumberValidator,
   timestampsArrayValidator,
+  correctionsArrayValidator,
   urlOrRelativeLinkValidator
 } = require('./validators');
 
@@ -43,6 +44,8 @@ const baseVideosSchema = strictObject({
   ).min(2), // if we need parts, should have at least 2
 
   timestamps: timestampsArrayValidator.required(),
+
+  corrections: correctionsArrayValidator,
 
   codeExamples: array(
     strictObject({

--- a/content/videos/pixels/painting-with-pixels/index.json
+++ b/content/videos/pixels/painting-with-pixels/index.json
@@ -53,6 +53,12 @@
       "title": "Outro"
     }
   ],
+  "corrections": [
+    {
+      "time": "02:40",
+      "title": "This old example is not using classes in JavaScript. Check the accompanying code for an updated version!"
+    }
+  ],
   "codeExamples": [
     {
       "title": "Painting with Pixels Array",


### PR DESCRIPTION
## Corrections

Add correction timestamps within content for outputting in youtube description. The syntax is same as that of normal timestamps, and in the generated description, the corrections are added after the timestamps.#1252

```json
"corrections": [
  {
    "time": "02:40",
    "title": "This old example is not using classes in JavaScript. Check the accompanying code for an updated version!"
  }
],
```

```txt
Corrections: 
02:40 This old example is not using classes in JavaScript. Check the accompanying code for an updated version!
```

--- 

## Added support for youtube video urls for `yt-desc`

```
npm run yt-desc https://youtu.be/0V3uYA1hafk
```

----

While working on this, I realised an error in the `yt-desc` script, that it only considers one url for each video, whereas in reality there can be multiple urls for a single video on the site.
For example, it does not recognise the following url
```
https://thecodingtrain.com/tracks/p5-tips-and-tricks/more-p5/pixel-array
``` 
because the canonical url for this video would be 
```
https://thecodingtrain.com/tracks/pixels/more-p5/pixel-array
```
So, in the future, the script have to be reworked to support multiple urls for a video. 