### PR TITLE
Change timeline button borders for readability

### DIFF
--- a/src/components/TimestampTimeline.module.css
+++ b/src/components/TimestampTimeline.module.css
@@ -11,8 +11,12 @@
   display: flex;
   padding: 0;
   cursor: pointer;
-  border-bottom: var(--border-red-light);
-  border-top: var(--border-red-light);
+  
+  &:first-child {
+    /* border-top will be set by the variant */
+    border-top: none !important;
+  }
+
   & span {
     display: flex;
     align-items: center;
@@ -68,6 +72,10 @@
   & .time {
     color: var(--red);
   }
+
+  & .timestamp {
+    border-top: var(--border-red-light);
+  }
 }
 
 .cyan {
@@ -82,6 +90,10 @@
 
   & .time {
     color: var(--cyan);
+  }
+
+  & .timestamp {
+    border-top: var(--border-cyan-light);
   }
 }
 

--- a/src/components/TimestampTimeline.module.css
+++ b/src/components/TimestampTimeline.module.css
@@ -11,6 +11,8 @@
   display: flex;
   padding: 0;
   cursor: pointer;
+  border-bottom: var(--border-red-light);
+  border-top: var(--border-red-light);
   & span {
     display: flex;
     align-items: center;

--- a/src/components/challenges/VideoSection.module.css
+++ b/src/components/challenges/VideoSection.module.css
@@ -150,7 +150,7 @@
   font-size: var(--maru-small);
   font-family: var(--maru-mono);
 
-  background-color: white;
+  background-color: var(--red-lightest);
 }
 
 .partTimeline.hide,

--- a/src/components/challenges/VideoSection.module.css
+++ b/src/components/challenges/VideoSection.module.css
@@ -150,8 +150,7 @@
   font-size: var(--maru-small);
   font-family: var(--maru-mono);
 
-  background-color: #fffcfc;
-  background-color: var(--red-lightest);
+  background-color: white;
 }
 
 .partTimeline.hide,

--- a/src/components/challenges/VideoSection.module.css
+++ b/src/components/challenges/VideoSection.module.css
@@ -149,6 +149,9 @@
   color: var(--cyan);
   font-size: var(--maru-small);
   font-family: var(--maru-mono);
+
+  background-color: #fffcfc;
+  background-color: var(--red-lightest);
 }
 
 .partTimeline.hide,

--- a/src/components/tracks/OverviewTimeline.js
+++ b/src/components/tracks/OverviewTimeline.js
@@ -80,7 +80,7 @@ const ChapterSection = memo(
     return (
       <ul className={css.chapterList}>
         {chapter.title && (
-          <li>
+          <li className={css.chapterListItem}>
             <button
               className={cn(
                 css.chapterTitle,
@@ -112,7 +112,7 @@ const ChapterSection = memo(
                 return (
                   <li
                     key={`${video.slug}-${partIndex}`}
-                    className={cn(css.videoItem, {
+                    className={cn(css.videoItem, css.chapterListItem, {
                       [css.seen]: hasSeenPart,
                       [css.last]: isLastVideo && partIndex === currentPartIndex
                     })}>
@@ -127,7 +127,7 @@ const ChapterSection = memo(
             ) : (
               <li
                 key={video.slug}
-                className={cn(css.videoItem, {
+                className={cn(css.videoItem, css.chapterListItem, {
                   [css.seen]: hasSeenVideo,
                   [css.last]: isLastVideo
                 })}>

--- a/src/components/tracks/OverviewTimeline.module.css
+++ b/src/components/tracks/OverviewTimeline.module.css
@@ -36,6 +36,13 @@
   padding: 0;
 }
 
+.chapterListItem {
+  /*
+  CSS 'border' interferes with the track stop lines, so we use a box shadow that matches 'border-red-light'.
+  */
+  box-shadow: 0 -1px 0 rgba(255, 0, 0, 0.1);
+}
+
 .chapterTitle {
   position: relative;
   height: var(--baseline);

--- a/src/components/tracks/VideoSection.module.css
+++ b/src/components/tracks/VideoSection.module.css
@@ -150,6 +150,8 @@
   color: var(--red);
   font-size: var(--maru-small);
   font-family: var(--maru-mono);
+
+  background-color: white;
 }
 
 .overviewTimeline.hide,

--- a/src/components/tracks/VideoSection.module.css
+++ b/src/components/tracks/VideoSection.module.css
@@ -151,7 +151,7 @@
   font-size: var(--maru-small);
   font-family: var(--maru-mono);
 
-  background-color: white;
+  background-color: var(--red-lightest);
 }
 
 .overviewTimeline.hide,

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -111,6 +111,7 @@
   --border-red-light: 1px solid rgba(255, 0, 0, 0.1);
   --border-orange: 1px solid var(--orange);
   --border-cyan: 1px solid var(--cyan);
+  --border-cyan-light: 1px solid rgba(0, 128, 128, 0.1);
   --border-pink: 1px solid var(--pink);
 
   --box-padding: 25px;


### PR DESCRIPTION
Just a minor change that's been bugging me on the site: the buttons in the timeline section don't have their own individual borders, and the background lines make them confusing while scrolling (pics attached below).

|Before|After|
|:-:|:-:|
|![image](https://github.com/CodingTrain/thecodingtrain.com/assets/49340972/c01dd988-56bf-4dd0-9f71-25646848c135)|![image](https://github.com/CodingTrain/thecodingtrain.com/assets/49340972/8ca2fe3e-acc4-4219-897c-b11ca4203523)|

Yep that's all. Love your content, and happy holidays :D