### PR TITLE
Hash-based challenge parts navigation

### DIFF
--- a/src/components/challenges/PartsTimeline.js
+++ b/src/components/challenges/PartsTimeline.js
@@ -4,7 +4,12 @@ import cn from 'classnames';
 import * as css from './PartsTimeline.module.css';
 import { Link } from 'gatsby';
 
-const PartsTimeline = ({ className, parts, currentPartIndex }) => {
+const PartsTimeline = ({
+  className,
+  parts,
+  currentPartIndex,
+  onSelection = () => {}
+}) => {
   return (
     <div className={cn(css.root, className)}>
       <div className={css.partsTimeline}>
@@ -16,19 +21,27 @@ const PartsTimeline = ({ className, parts, currentPartIndex }) => {
                 [css.seen]: index <= currentPartIndex,
                 [css.last]: index === currentPartIndex
               })}>
-              <Link to={`#part-${index + 1}`}>{part.title}</Link>
+              <Link to={`#part-${index + 1}`} onClick={onSelection}>
+                {part.title}
+              </Link>
             </li>
           ))}
         </ul>
       </div>
       <div className={css.navigation}>
         {currentPartIndex > 0 && (
-          <Link to={`#part-${currentPartIndex}`} className={css.navButton}>
+          <Link
+            to={`#part-${currentPartIndex}`}
+            className={css.navButton}
+            onClick={onSelection}>
             Previous
           </Link>
         )}
         {currentPartIndex < parts.length - 1 && (
-          <Link to={`#part-${currentPartIndex + 2}`} className={css.navButton}>
+          <Link
+            to={`#part-${currentPartIndex + 2}`}
+            className={css.navButton}
+            onClick={onSelection}>
             Next
           </Link>
         )}

--- a/src/components/challenges/PartsTimeline.js
+++ b/src/components/challenges/PartsTimeline.js
@@ -3,6 +3,7 @@ import cn from 'classnames';
 
 import * as css from './PartsTimeline.module.css';
 import { Link } from 'gatsby';
+import { buildPartHash } from '../../utils';
 
 const PartsTimeline = ({
   className,
@@ -21,7 +22,7 @@ const PartsTimeline = ({
                 [css.seen]: index <= currentPartIndex,
                 [css.last]: index === currentPartIndex
               })}>
-              <Link to={`#part-${index + 1}`} onClick={onSelection}>
+              <Link to={buildPartHash(index)} onClick={onSelection}>
                 {part.title}
               </Link>
             </li>
@@ -31,7 +32,7 @@ const PartsTimeline = ({
       <div className={css.navigation}>
         {currentPartIndex > 0 && (
           <Link
-            to={`#part-${currentPartIndex}`}
+            to={buildPartHash(currentPartIndex - 1)}
             className={css.navButton}
             onClick={onSelection}>
             Previous
@@ -39,7 +40,7 @@ const PartsTimeline = ({
         )}
         {currentPartIndex < parts.length - 1 && (
           <Link
-            to={`#part-${currentPartIndex + 2}`}
+            to={buildPartHash(currentPartIndex + 1)}
             className={css.navButton}
             onClick={onSelection}>
             Next

--- a/src/components/challenges/PartsTimeline.js
+++ b/src/components/challenges/PartsTimeline.js
@@ -1,17 +1,10 @@
-import React, { memo, useState } from 'react';
+import React, { memo } from 'react';
 import cn from 'classnames';
 
 import * as css from './PartsTimeline.module.css';
 import { Link } from 'gatsby';
 
-const PartsTimeline = ({ className, parts, onPartChange }) => {
-  const [currentPartIndex, setCurrentPartIndex] = useState(0);
-
-  const updatePartIndex = (index) => {
-    onPartChange(parts[index]);
-    setCurrentPartIndex(index);
-  };
-
+const PartsTimeline = ({ className, parts, currentPartIndex }) => {
   return (
     <div className={cn(css.root, className)}>
       <div className={css.partsTimeline}>
@@ -23,38 +16,19 @@ const PartsTimeline = ({ className, parts, onPartChange }) => {
                 [css.seen]: index <= currentPartIndex,
                 [css.last]: index === currentPartIndex
               })}>
-              <Link
-                to="#"
-                onClick={(event) => {
-                  event.preventDefault();
-                  updatePartIndex(index);
-                }}>
-                {part.title}
-              </Link>
+              <Link to={`#part-${index + 1}`}>{part.title}</Link>
             </li>
           ))}
         </ul>
       </div>
       <div className={css.navigation}>
         {currentPartIndex > 0 && (
-          <Link
-            to="#"
-            className={css.navButton}
-            onClick={(event) => {
-              event.preventDefault();
-              updatePartIndex(currentPartIndex - 1);
-            }}>
+          <Link to={`#part-${currentPartIndex}`} className={css.navButton}>
             Previous
           </Link>
         )}
         {currentPartIndex < parts.length - 1 && (
-          <Link
-            to="#"
-            className={css.navButton}
-            onClick={(event) => {
-              event.preventDefault();
-              updatePartIndex(currentPartIndex + 1);
-            }}>
+          <Link to={`#part-${currentPartIndex + 2}`} className={css.navButton}>
             Next
           </Link>
         )}

--- a/src/components/challenges/VideoSection.js
+++ b/src/components/challenges/VideoSection.js
@@ -24,7 +24,7 @@ const VideoSection = ({ challenge }) => {
   const hasMultiParts = challenge.parts?.length > 0;
   const [showTimestamps, setShowTimestamps] = useState(!hasMultiParts);
 
-  const activePartIndex = useChallengePartIndex(challenge.parts?.length ?? 1);
+  const activePartIndex = useChallengePartIndex(challenge.parts?.length || 1);
   const activePart = challenge.parts?.[activePartIndex] ?? challenge;
   const { videoId, nebulaSlug, timestamps } = activePart;
   const hasTimestamps = timestamps?.length > 0;

--- a/src/components/challenges/VideoSection.js
+++ b/src/components/challenges/VideoSection.js
@@ -148,6 +148,7 @@ const VideoSection = ({ challenge }) => {
                     })}
                     parts={challenge.parts}
                     currentPartIndex={activePartIndex}
+                    onSelection={() => setShowTimeline(false)}
                   />
                 )}
                 {hasTimestamps && (

--- a/src/components/challenges/VideoSection.js
+++ b/src/components/challenges/VideoSection.js
@@ -9,6 +9,7 @@ import PartsTimeline from './PartsTimeline';
 import NebulaVideoRow from '../NebulaVideoRow';
 
 import { filteredPath } from '../../utils';
+import { useChallengePartIndex } from '../../hooks';
 
 import * as css from './VideoSection.module.css';
 
@@ -23,9 +24,8 @@ const VideoSection = ({ challenge }) => {
   const hasMultiParts = challenge.parts?.length > 0;
   const [showTimestamps, setShowTimestamps] = useState(!hasMultiParts);
 
-  const [activePart, setActivePart] = useState(
-    challenge.parts?.[0] ?? challenge
-  );
+  const activePartIndex = useChallengePartIndex(challenge.parts?.length ?? 1);
+  const activePart = challenge.parts?.[activePartIndex] ?? challenge;
   const { videoId, nebulaSlug, timestamps } = activePart;
   const hasTimestamps = timestamps?.length > 0;
   const hasTimeline = hasMultiParts || hasTimestamps;
@@ -147,10 +147,7 @@ const VideoSection = ({ challenge }) => {
                       [css.hide]: showTimestamps
                     })}
                     parts={challenge.parts}
-                    onPartChange={(part) => {
-                      setActivePart(part);
-                      setShowTimeline(false);
-                    }}
+                    currentPartIndex={activePartIndex}
                   />
                 )}
                 {hasTimestamps && (

--- a/src/components/tracks/OverviewTimeline.js
+++ b/src/components/tracks/OverviewTimeline.js
@@ -2,7 +2,7 @@ import React, { memo, useState } from 'react';
 import cn from 'classnames';
 import { Link } from 'gatsby';
 
-import { useChallengePartIndex, usePersistScrollPosition } from '../../hooks';
+import { usePersistScrollPosition } from '../../hooks';
 
 import * as css from './OverviewTimeline.module.css';
 
@@ -20,12 +20,10 @@ const usePaths = (chapters, track, trackPosition) => {
     );
   const currentVideo =
     chapters[trackPosition.chapterIndex].videos[trackPosition.videoIndex];
-  const totalParts = flatTrack.filter(
-    (video) => video.slug === currentVideo.slug
-  ).length;
-  const partIndex = useChallengePartIndex(totalParts);
   const currentIndex = flatTrack.findIndex(
-    (video) => video.slug === currentVideo.slug && video.partIndex === partIndex
+    (video) =>
+      video.slug === currentVideo.slug &&
+      video.partIndex === trackPosition.partIndex
   );
   const prevVideo = flatTrack[currentIndex - 1];
   const nextVideo = flatTrack[currentIndex + 1];
@@ -39,15 +37,11 @@ const usePaths = (chapters, track, trackPosition) => {
     }
     return null;
   };
-  return [computePath(prevVideo), computePath(nextVideo), partIndex];
+  return [computePath(prevVideo), computePath(nextVideo)];
 };
 
 const OverviewTimeline = ({ className, chapters, track, trackPosition }) => {
-  const [previousVideo, nextVideo, currentPartIndex] = usePaths(
-    chapters,
-    track,
-    trackPosition
-  );
+  const [previousVideo, nextVideo] = usePaths(chapters, track, trackPosition);
 
   const timelineRef = usePersistScrollPosition(track.slug, 'tracks');
   return (
@@ -61,7 +55,6 @@ const OverviewTimeline = ({ className, chapters, track, trackPosition }) => {
             chapters={chapters}
             track={track}
             trackPosition={trackPosition}
-            currentPartIndex={currentPartIndex}
           />
         ))}
       </div>
@@ -82,14 +75,7 @@ const OverviewTimeline = ({ className, chapters, track, trackPosition }) => {
 };
 
 const ChapterSection = memo(
-  ({
-    chapter,
-    chapterIndex,
-    chapters,
-    track,
-    trackPosition,
-    currentPartIndex
-  }) => {
+  ({ chapter, chapterIndex, chapters, track, trackPosition }) => {
     const hasSeenChapter = chapterIndex < trackPosition.chapterIndex;
     const isThisChapter = chapterIndex === trackPosition.chapterIndex;
     const trackPath = `/tracks/${track.slug}`;
@@ -125,6 +111,7 @@ const ChapterSection = memo(
 
             return isMultiPart ? (
               video.parts.map((part, partIndex) => {
+                const currentPartIndex = trackPosition.partIndex;
                 const hasSeenPart =
                   hasSeenVideo &&
                   (videoIndex < currentVideoIndex ||

--- a/src/components/tracks/OverviewTimeline.js
+++ b/src/components/tracks/OverviewTimeline.js
@@ -12,12 +12,8 @@ const usePaths = (chapters, track, trackPosition) => {
     .flatMap((chapter) => chapter.videos)
     .flatMap((video) =>
       video.parts?.length > 0
-        ? video.parts.map((_, partIndex) => ({
-            slug: video.slug,
-            partIndex,
-            isMultiPart: true
-          }))
-        : [{ slug: video.slug, partIndex: 0, isMultiPart: false }]
+        ? video.parts.map((_, partIndex) => ({ slug: video.slug, partIndex }))
+        : [{ slug: video.slug, partIndex: 0 }]
     );
   const currentVideo =
     chapters[trackPosition.chapterIndex].videos[trackPosition.videoIndex];
@@ -30,7 +26,7 @@ const usePaths = (chapters, track, trackPosition) => {
   const nextVideo = flatTrack[currentIndex + 1];
   const computePath = (video) => {
     if (video) {
-      const hash = video.isMultiPart ? buildPartHash(video.partIndex) : '';
+      const hash = buildPartHash(video.partIndex);
       return {
         ...video,
         path: `/tracks/${track.slug}/${video.slug}${hash}`

--- a/src/components/tracks/OverviewTimeline.js
+++ b/src/components/tracks/OverviewTimeline.js
@@ -3,6 +3,7 @@ import cn from 'classnames';
 import { Link } from 'gatsby';
 
 import { usePersistScrollPosition } from '../../hooks';
+import { buildPartHash } from '../../utils';
 
 import * as css from './OverviewTimeline.module.css';
 
@@ -29,7 +30,7 @@ const usePaths = (chapters, track, trackPosition) => {
   const nextVideo = flatTrack[currentIndex + 1];
   const computePath = (video) => {
     if (video) {
-      const hash = video.isMultiPart ? `#part-${video.partIndex + 1}` : '';
+      const hash = video.isMultiPart ? buildPartHash(video.partIndex) : '';
       return {
         ...video,
         path: `/tracks/${track.slug}/${video.slug}${hash}`
@@ -137,7 +138,9 @@ const ChapterSection = memo(
                       [css.last]: isLastVideo && partIndex === currentPartIndex
                     })}>
                     <Link
-                      to={`${trackPath}/${video.slug}#part-${partIndex + 1}`}
+                      to={`${trackPath}/${video.slug}${buildPartHash(
+                        partIndex
+                      )}`}
                       onClick={onSelection}>
                       {video.title} - {part.title}
                     </Link>

--- a/src/components/tracks/OverviewTimeline.js
+++ b/src/components/tracks/OverviewTimeline.js
@@ -40,7 +40,13 @@ const usePaths = (chapters, track, trackPosition) => {
   return [computePath(prevVideo), computePath(nextVideo)];
 };
 
-const OverviewTimeline = ({ className, chapters, track, trackPosition }) => {
+const OverviewTimeline = ({
+  className,
+  chapters,
+  track,
+  trackPosition,
+  onSelection = () => {}
+}) => {
   const [previousVideo, nextVideo] = usePaths(chapters, track, trackPosition);
 
   const timelineRef = usePersistScrollPosition(track.slug, 'tracks');
@@ -55,17 +61,24 @@ const OverviewTimeline = ({ className, chapters, track, trackPosition }) => {
             chapters={chapters}
             track={track}
             trackPosition={trackPosition}
+            onSelection={onSelection}
           />
         ))}
       </div>
       <div className={css.navigation}>
         {previousVideo !== null && (
-          <Link className={css.navButton} to={previousVideo.path}>
+          <Link
+            className={css.navButton}
+            to={previousVideo.path}
+            onClick={onSelection}>
             Previous
           </Link>
         )}
         {nextVideo !== null && (
-          <Link className={css.navButton} to={nextVideo.path}>
+          <Link
+            className={css.navButton}
+            to={nextVideo.path}
+            onClick={onSelection}>
             Next
           </Link>
         )}
@@ -75,7 +88,7 @@ const OverviewTimeline = ({ className, chapters, track, trackPosition }) => {
 };
 
 const ChapterSection = memo(
-  ({ chapter, chapterIndex, chapters, track, trackPosition }) => {
+  ({ chapter, chapterIndex, chapters, track, trackPosition, onSelection }) => {
     const hasSeenChapter = chapterIndex < trackPosition.chapterIndex;
     const isThisChapter = chapterIndex === trackPosition.chapterIndex;
     const trackPath = `/tracks/${track.slug}`;
@@ -124,7 +137,8 @@ const ChapterSection = memo(
                       [css.last]: isLastVideo && partIndex === currentPartIndex
                     })}>
                     <Link
-                      to={`${trackPath}/${video.slug}#part-${partIndex + 1}`}>
+                      to={`${trackPath}/${video.slug}#part-${partIndex + 1}`}
+                      onClick={onSelection}>
                       {video.title} - {part.title}
                     </Link>
                   </li>
@@ -137,7 +151,9 @@ const ChapterSection = memo(
                   [css.seen]: hasSeenVideo,
                   [css.last]: isLastVideo
                 })}>
-                <Link to={`${trackPath}/${video.slug}`}>{video.title}</Link>
+                <Link to={`${trackPath}/${video.slug}`} onClick={onSelection}>
+                  {video.title}
+                </Link>
               </li>
             );
           })}

--- a/src/components/tracks/VideoSection.js
+++ b/src/components/tracks/VideoSection.js
@@ -35,7 +35,7 @@ const VideoSection = ({ track, video, trackPosition, mainTitle }) => {
 
   const { title, topics, languages } = video;
 
-  const totalParts = video.parts?.length ?? 1;
+  const totalParts = video.parts?.length || 1;
   const partIndex = useChallengePartIndex(totalParts);
   const part = video.parts?.[partIndex];
   const videoId = part?.videoId ?? video.videoId;

--- a/src/components/tracks/VideoSection.js
+++ b/src/components/tracks/VideoSection.js
@@ -35,7 +35,8 @@ const VideoSection = ({ track, video, trackPosition, mainTitle }) => {
 
   const { title, topics, languages } = video;
 
-  const partIndex = useChallengePartIndex();
+  const totalParts = video.parts?.length ?? 1;
+  const partIndex = useChallengePartIndex(totalParts);
   const part = video.parts?.[partIndex];
   const videoId = part?.videoId ?? video.videoId;
   const nebulaSlug = part?.nebulaSlug ?? video.nebulaSlug;

--- a/src/components/tracks/VideoSection.js
+++ b/src/components/tracks/VideoSection.js
@@ -37,6 +37,7 @@ const VideoSection = ({ track, video, trackPosition, mainTitle }) => {
 
   const totalParts = video.parts?.length || 1;
   const partIndex = useChallengePartIndex(totalParts);
+  trackPosition = { ...trackPosition, partIndex };
   const part = video.parts?.[partIndex];
   const videoId = part?.videoId ?? video.videoId;
   const nebulaSlug = part?.nebulaSlug ?? video.nebulaSlug;

--- a/src/components/tracks/VideoSection.js
+++ b/src/components/tracks/VideoSection.js
@@ -35,8 +35,7 @@ const VideoSection = ({ track, video, trackPosition, mainTitle }) => {
 
   const { title, topics, languages } = video;
 
-  const totalParts = video.parts?.length || 1;
-  const partIndex = useChallengePartIndex(totalParts);
+  const partIndex = useChallengePartIndex(video.parts?.length || 1);
   trackPosition = { ...trackPosition, partIndex };
   const part = video.parts?.[partIndex];
   const videoId = part?.videoId ?? video.videoId;
@@ -181,6 +180,7 @@ const VideoSection = ({ track, video, trackPosition, mainTitle }) => {
                   chapters={chapters}
                   track={track}
                   trackPosition={trackPosition}
+                  onSelection={() => setShowTimeline(false)}
                 />
               )}
             </div>

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -143,9 +143,13 @@ export const useIsFirstRender = () => {
  * which has been stored in the `location.state` object using the `Link.state`
  * property.
  *
+ * @param totalParts {number} total number of parts of the challenge (1 if the
+ * challenge is not multi-part)
+ * 
  * @returns {number} challenge part index
  */
-export const useChallengePartIndex = () => {
-  const { state } = useLocation();
-  return state?.challengePartIndex ?? 0;
+export const useChallengePartIndex = (totalParts) => {
+  const { hash } = useLocation();
+  const [match, partNumberStr] = hash.match(/#part-([1-9][0-9]*)/) || [false];
+  return match ? Math.min(parseInt(partNumberStr), totalParts) - 1 : 0;
 };

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -139,9 +139,13 @@ export const useIsFirstRender = () => {
 };
 
 /**
- * Returns the challenge part index (0 if the challenge is not multi-part)
- * which has been stored in the `location.state` object using the `Link.state`
- * property.
+ * If the current URL (and hash value) corresponds to a part from a multi-part
+ * coding challenge (within a challenge page or a track page), this hook returns
+ * the zero-based index of this part, else it returns 0.
+ *
+ * The hash value should look like `#part-3`. If the part number if larger than
+ * the `totalParts` parameter, the returned index corresponds to the last part
+ * of the challenge (`totalParts - 1`).
  *
  * @param totalParts {number} total number of parts of the challenge (1 if the
  * challenge is not multi-part)

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -144,7 +144,7 @@ export const useIsFirstRender = () => {
  * part.
  *
  * If the hash value doesn't match the format `#part-{partNumber}` where
- * `0 <= partNumber <= partsCount`, this hook returns 0.
+ * `1 <= partNumber <= partsCount`, this hook returns 0.
  *
  * @param partsCount {number} total number of parts of the challenge (1 if
  * the challenge is not multi-part)

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -139,21 +139,27 @@ export const useIsFirstRender = () => {
 };
 
 /**
- * If the current URL (and hash value) corresponds to a part from a multi-part
- * coding challenge (within a challenge page or a track page), this hook returns
- * the zero-based index of this part, else it returns 0.
+ * If the current URL hash value (fragment) matches a part number (from a
+ * multi-part coding challenge), this hook returns the zero-based index of this
+ * part.
  *
- * The hash value should look like `#part-3`. If the part number if larger than
- * the `totalParts` parameter, the returned index corresponds to the last part
- * of the challenge (`totalParts - 1`).
+ * If the hash value doesn't match the format `#part-{partNumber}` where
+ * `0 <= partNumber <= partsCount`, this hook returns 0.
  *
- * @param totalParts {number} total number of parts of the challenge (1 if the
- * challenge is not multi-part)
- * 
+ * @param partsCount {number} total number of parts of the challenge (1 if
+ * the challenge is not multi-part)
+ *
  * @returns {number} challenge part index
+ *
+ * @example
+ * with hash "#part-1", useChallengePartIndex(3) === 0
+ * with hash "#part-3", useChallengePartIndex(3) === 2
+ * with hash "#part-8", useChallengePartIndex(2) === 0;
+ * with hash "#part-abc", useChallengePartIndex(3) === 0
  */
-export const useChallengePartIndex = (totalParts) => {
+export const useChallengePartIndex = (partsCount) => {
   const { hash } = useLocation();
   const [match, partNumberStr] = hash.match(/#part-([1-9][0-9]*)/) || [false];
-  return match ? Math.min(parseInt(partNumberStr), totalParts) - 1 : 0;
+  const partIndex = match ? parseInt(partNumberStr) - 1 : 0;
+  return partIndex < partsCount ? partIndex : 0;
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -77,3 +77,17 @@ export const randomElement = (array) => {
   const index = Math.floor(Math.random() * array.length);
   return array[index];
 };
+
+/**
+ * Creates a URL hash value (fragment) refering to a specific part of a
+ * multi-part coding challenge. Part 1 of a challenge has no hash value.
+ *
+ * @param partIndex {number} Zero-based part index
+ *
+ * @example
+ * buildPartHash(0) === ""
+ * buildPartHash(1) === "#part-2"
+ */
+export const buildPartHash = (partIndex) => {
+  return partIndex > 0 ? `#part-${partIndex + 1}` : '';
+};


### PR DESCRIPTION
Choo choo! :steam_locomotive: 

In response to #1319, I'm giving a go at implementing hash-based navigation between challenge parts. This would allow us to reference a specific challenge part by its URL. Example: https://thecodingtrain.com/challenges/40-word-counter#part-3.

A few observations on my current implementation : 
- `/challenges/40-word-counter` takes us to the 1st part of the challenge
- `/challenges/40-word-counter#part-1` takes us to the 1st part of the challenge
- `/challenges/40-word-counter#part-2` takes us to the 2nd part of the challenge
- `/challenges/40-word-counter#part-3` takes us to the 3rd part of the challenge

Whatever hash value is passed to the URL by the user, the URL is not modified (unless we click on another part link or prev/next button of course) : 
- `/challenges/40-word-counter#part-42` takes us to the 3rd (last) part of the challenge (`#part-42` stays in the URL)
- `/challenges/40-word-counter#part-abc` takes us to the 1st part of the challenge (`#part-abc` stays in the URL)

I added this on challenge and track pages containing multi-part challenges.

Previews : 
- https://deploy-preview-1380--codingtrain.netlify.app/challenges/40-word-counter
- https://deploy-preview-1380--codingtrain.netlify.app/tracks/games/72-frogger#part-3

I'm still working on cleaning up some of the code. I welcome any feedback on this feature :grinning: 