### PR TITLE
Fix table overflow issue on Chromium browsers

### DIFF
--- a/src/templates/guide.module.css
+++ b/src/templates/guide.module.css
@@ -189,6 +189,10 @@
   padding: 0 var(--spacing-xsmall);
 }
 
+.td:not(:first-child) {
+  word-break: break-word;
+}
+
 .tr:last-child .td {
   border-bottom: none;
 }
@@ -214,12 +218,6 @@
   .videoContainer {
     padding-bottom: var(--baseline-box-7x);
   }
-  .table {
-    & table {
-      table-layout: fixed;
-      text-wrap: wrap;
-    }
-  }
 }
 
 @media (--xsmall) {
@@ -228,11 +226,5 @@
   }
   .itemSpacer {
     display: none;
-  }
-  .table {
-    & table {
-      table-layout: fixed;
-      text-wrap: wrap;
-    }
   }
 }

--- a/src/templates/guide.module.css
+++ b/src/templates/guide.module.css
@@ -214,6 +214,12 @@
   .videoContainer {
     padding-bottom: var(--baseline-box-7x);
   }
+  .table {
+    & table {
+      table-layout: fixed;
+      text-wrap: wrap;
+    }
+  }
 }
 
 @media (--xsmall) {
@@ -222,5 +228,11 @@
   }
   .itemSpacer {
     display: none;
+  }
+  .table {
+    & table {
+      table-layout: fixed;
+      text-wrap: wrap;
+    }
   }
 }


### PR DESCRIPTION
## Description

This PR fixes an issue where the table on the "Maintaining the Website Guide" page overflows due to the YouTube URL not wrapping on Chromium-based browsers. The issue was mentioned in [this comment](https://github.com/CodingTrain/thecodingtrain.com/pull/1554#issuecomment-2097954963).

## Steps to Reproduce

1. Open the "Maintaining the Website Guide" page on a Chromium-based browser (e.g., Google Chrome, DuckDuckGo, Brave) using a desktop or mobile device. [here](https://thecodingtrain.com/guides/maintain-website-guide)
2. Scroll down to the table section.

## Expected Behavior

The table should display correctly, with the YouTube URLs wrapping to the next line if they exceed the table cell width.

## Actual Behavior

On Chromium-based browsers, the YouTube URLs do not wrap, causing the table to overflow horizontally.

## Screenshots

| Before | After |
|:------:|:-----:|
| ![Before](https://github.com/CodingTrain/thecodingtrain.com/assets/32950332/5b4c90d8-2b40-424a-af70-87298069d9e4) | ![After](https://github.com/CodingTrain/thecodingtrain.com/assets/32950332/70fc6f3e-6989-439a-b426-1a2a91fd7031) |


## Testing

- [x] Tested on Google Chrome (Android)
- [x] Tested on DuckDuckGo (Android)
- [x] Tested on Brave (Android)
- [x] Tested on Mozilla Firefox (Android) (has no effect)
- [ ] Tested on Safari (iOS) [If you have access to an iPhone, please confirm and check this box]
