### PR TITLE
Remove passive event "polyfill" and unused `randomElement()` utility

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,6 +1,5 @@
 import React, { useMemo, useRef, useEffect, useState } from 'react';
 import { useLocation } from '@reach/router';
-import { passiveEventArg } from '../utils';
 
 /**
  * Takes an array of images nodes and makes a hashed object based on their names
@@ -94,10 +93,11 @@ export const usePersistScrollPosition = (key, _namespace) => {
     }
 
     lastKey = key;
-    current.addEventListener('scroll', onScroll, passiveEventArg);
+
+    current.addEventListener('scroll', onScroll, { passive: true });
 
     return () => {
-      current.removeEventListener('scroll', onScroll, passiveEventArg);
+      current.removeEventListener('scroll', onScroll);
     };
   }, [key, namespace]);
 
@@ -125,7 +125,7 @@ export const getReadableDate = (dateString) => {
 
 /**
  * This hook will return true for the first render on the server and for the
- * first render on the client. Otherwhise, it will return false.
+ * first render on the client. Otherwise, it will return false.
  *
  * This function encapsulates a hook so "rules of hooks" apply to it.
  * @see {@link https://reactjs.org/docs/hooks-rules.html}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,32 +1,5 @@
 import slugify from 'slugify';
 
-// so it doesn't throw if no window
-const win =
-  typeof window !== 'undefined' ? window : { screen: {}, navigator: {} };
-
-// passive events test
-// adapted from https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
-let passiveOptionAccessed = false;
-const options = {
-  get passive() {
-    return (passiveOptionAccessed = true);
-  }
-};
-
-// have to set and remove a no-op listener instead of null
-// (which was used previously), because Edge v15 throws an error
-// when providing a null callback.
-// https://github.com/rafgraph/detect-passive-events/pull/3
-const noop = () => {};
-win.addEventListener && win.addEventListener('p', noop, options);
-win.removeEventListener && win.removeEventListener('p', noop, false);
-
-export const supportsPassiveEvents = passiveOptionAccessed;
-
-export const passiveEventArg = supportsPassiveEvents
-  ? { capture: false, passive: true }
-  : false;
-
 export const stringValueOrAll = (str) => {
   return typeof str === 'string' && str !== '' ? str : 'all';
 };
@@ -70,16 +43,8 @@ export const shuffleCopy = (array) => {
   return copy;
 };
 
-export const randomElement = (array) => {
-  if (array.length === 0) {
-    return null;
-  }
-  const index = Math.floor(Math.random() * array.length);
-  return array[index];
-};
-
 /**
- * Creates a URL hash value (fragment) refering to a specific part of a
+ * Creates a URL hash value (fragment) referring to a specific part of a
  * multi-part coding challenge. Part 1 of a challenge has no hash value.
  *
  * @param partIndex {number} Zero-based part index


### PR DESCRIPTION
We can remove this passive event listener polyfill thing - I don't think it ever was needed as it was introduced in 2022 (#82) but only exists because of old/dead Edge browser (pre Chromium I assume) from before 2017 and IE 11.
https://caniuse.com/passive-event-listener

I corrected the listeners usage too. The `capture` option is `false` by default, and the `passive` option is not required when removing the listener (it's not even a valid option to begin with).
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#passive
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener#parameters

I also noticed the `randomElement` utility was never used and can be safely removed from the codebase.