### PR TITLE
Discord Invite Update

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -30,7 +30,7 @@
 /flock-view https://editor.p5js.org/codingtrain/sketches/fFNCIQw4e 302!
 /decade https://donorbox.org/to-the-power-of-10 302!
 /noc https://nostarch.com/nature-code 302!
-/discord https://discord.com/servers/coding-train-choo-choo-276096133695143936 302!
+/discord https://discord.gg/coding-train-choo-choo-276096133695143936 302!
 /pi2022 https://editor.p5js.org/codingtrain/full/U11UYbgVc 302!
 /colors https://coding-train-colors.vercel.app/ 302!
 /wheel https://editor.p5js.org/kingpepe/full/n_KhX8lYC 302!


### PR DESCRIPTION
We've lost the vanity page for the server (maybe it comes back with level 3 boosts?) but this invite link should work.