### PR TITLE
Fix import assertions to import attributes syntax

### DIFF
--- a/netlify/edge-functions/yt/index.mjs
+++ b/netlify/edge-functions/yt/index.mjs
@@ -1,5 +1,5 @@
 // The JSON lookup gets generated at build time, do not manually edit. See `node-scripts/generate-youtube-redirects.js`
-import redirects from './redirects.json' assert { type: 'json' };
+import redirects from './redirects.json' with { type: 'json' };
 
 export default async (request) => {
   const url = new URL(request.url);


### PR DESCRIPTION
Hey @shiffman, hope all is well.

I noticed an error in the Netlify pipeline when you merged your PR yesterday. This should fix the problem.

Import assertions were superseded by import attributes after we shipped this YouTube redirect feature on the site. Node 22+ doesn't support this assert syntax anymore. I think we're seeing this issue appear now because Node 20 is EOL, and Netlify packages edge functions to run on Deno Deploy where the actual runtime is Deno AFAIK.

<img width="2218" height="310" alt="CleanShot 2026-08-04 at 14 51 20@2x" src="https://github.com/user-attachments/assets/5acc1f52-47a7-4b6c-9b15-b9a7fcd59120" />

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with
https://v8.dev/features/import-attributes
